### PR TITLE
fix: require Node version to be at least 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "private": false,
   "engines": {
-    "node": ">=16",
+    "node": ">=20",
     "pnpm": "8"
   },
   "repository": {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Bumps the required Node version to be 20 or above. 

(We technically have been requiring `>=20` as this is the version range specified in the `root package.json` of the main repo.)

<!-- Feel free to add any additional description of changes below this line -->
