### PR TITLE
fix: remove headlessui dist import

### DIFF
--- a/src/drop-down/drop-down.tsx
+++ b/src/drop-down/drop-down.tsx
@@ -2,49 +2,29 @@ import React, { createContext, useContext, useRef } from "react";
 import { Menu } from "@headlessui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
-import { Props } from "@headlessui/react/dist/types";
 
-type MenuTag = React.ExoticComponent<{
-	children?: React.ReactNode;
-}>;
-
-interface MenuRenderPropArg {
-	open: boolean;
-	close: () => void;
+interface MenuItemsProps {
+	children: React.ReactNode;
+	className?: string;
 }
 
-type DropdownMenuProps = Props<
-	MenuTag,
-	MenuRenderPropArg,
-	never,
-	{
-		__demoMode?: boolean;
-	}
->;
-
-export type DropdownProps = DropdownMenuProps & {
+export interface DropdownProps {
+	children: React.ReactNode;
 	dropup?: boolean;
 	id?: string;
-};
-
-export interface ButtonRenderPropArg {
-	open: boolean;
 }
 
-type ButtonPropsWeControl = "aria-controls" | "aria-expanded" | "aria-haspopup";
+interface DropDownButtonProps
+	extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+	children: React.ReactNode;
+	className?: string;
+}
 
-type DropDownButtonProps = Props<
-	"button",
-	ButtonRenderPropArg,
-	ButtonPropsWeControl,
-	{
-		disabled?: boolean;
-	}
->;
-
-type DropDownContextProps = DropdownProps & {
+interface DropDownContextProps {
+	dropup?: boolean;
 	menuButtonRef: React.MutableRefObject<HTMLButtonElement | null>;
-};
+}
+
 const DropDownContext = createContext<DropDownContextProps>({
 	menuButtonRef: React.createRef(),
 });
@@ -55,7 +35,7 @@ const dropUpItems = dropDownItems + " transform -translate-y-full top-0";
 const toggleClassNames =
 	"cursor-pointer border-3 border-solid w-full block text-center touch-manipulation bg-background-quaternary text-foreground-secondary px-3 py-1.5 relative hover:bg-foreground-secondary hover:text-background-secondary btn-block border-foreground-secondary";
 
-export const MenuItems = React.forwardRef<HTMLDivElement, DropDownButtonProps>(
+export const MenuItems = React.forwardRef<HTMLDivElement, MenuItemsProps>(
 	({ children, className }, ref): JSX.Element => {
 		const { dropup, menuButtonRef } = useContext(DropDownContext);
 
@@ -95,14 +75,14 @@ const DropDownButton = ({
 
 export const Dropdown = ({
 	children,
+	id,
 	dropup,
-	...props
 }: DropdownProps): JSX.Element => {
 	const menuButtonRef = useRef(null);
 	const context = { dropup, menuButtonRef };
 	return (
 		<DropDownContext.Provider value={context}>
-			<Menu className="relative w-full" as="div" {...props}>
+			<Menu className="relative w-full" as="div" id={id}>
 				{children}
 			</Menu>
 		</DropDownContext.Provider>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Issue

We are currently importing some props types from `@headlessui/react/dist/types`. This was intended to be a workaround until https://github.com/tailwindlabs/headlessui/issues/2306 is resolved. 

The `headlessui` issue has been fixed, but I'm still experiencing the error "type X from module Y but cannot be named" if I write the props definition as follows:

```ts
import { Menu } from '@headlessui/react'

type MenuItemsProps = React.ComponentPropsWithoutRef<typeof Menu.Items>
```

## Solution

In order to remove the `@headlessui/react/dist/types` import, I simply rewrite the props interfaces based on exactly which props the components support. This allows us to have more control over the props the components should accept, as well as removing our dependence on the `headlessui` props interfaces (this helps keep our public interface stable in the case where we replace `headlessui` with something else).

## Testing

- The changes have no type check errors 
- `pnpm run build` runs successfully

## Other notes

Related PR: https://github.com/freeCodeCamp/freeCodeCamp/pull/51184.

<!-- Feel free to add any additional description of changes below this line -->
