### PR TITLE
chore(storybook): prevent storybook from automatically opening in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format": "prettier --write .",
     "lint": "prettier --check .",
     "start": "pnpm run develop",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --no-open",
     "storybook:theming": "pnpm run storybook --no-manager-cache",
     "clean": "rm -rf dist/*",
     "gen-component": "ts-node ./utils/gen-component-script",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Prevents Storybook from automatically opening in the browser on `pnpm run storybook`.

(I hope I'm not the only one annoyed by this behavior.)

<!-- Feel free to add any additional description of changes below this line -->
