### PR TITLE
refactor: keep normalize.css pristine

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -3,6 +3,14 @@
 @tailwind base;
 
 @layer base {
+	*,
+	::before,
+	::after {
+		/* Override the browser default border width in order to style individual border sides
+		* Ref: https://stackoverflow.com/a/76961084
+		*/
+		border-width: 0;
+	}
 	/* Override Tailwind's default `text-decoration` rule. */
 	/* https://github.com/tailwindlabs/tailwindcss/blob/master/src/css/preflight.css#L85 */
 	a {

--- a/src/normalize.css
+++ b/src/normalize.css
@@ -1,12 +1,4 @@
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-*,
-::before,
-::after {
-	/* Override the browser default border width in order to style individual border sides
-   * Ref: https://stackoverflow.com/a/76961084
-   */
-	border-width: 0;
-}
 html {
 	font-family: sans-serif;
 	-ms-text-size-adjust: 100%;


### PR DESCRIPTION
## Description

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR moves a CSS rule out of the `normalize.css` file.

The rule was added during the Modal component implementation (ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/54044#discussion_r1519553439). But I'm looking at all of the stylesheets in the package again, I don't think we should add custom rules to `normalize.css` as it would make the `normalize` upgrade more complicated (as opposed to just copy-pasting).

The candidates to house the change are `global-element-styles.css` and `base.css`. I tried adding the code to `global-element-styles.css` but it didn't work, so I applied the change to `base.css` instead. `base.css` also makes more sense as the file imports Tailwind styles, and the rule we are adding is also recommended by Tailwind.

(Heads-up: I'll have more CSS cleanup coming, but I'm currently ironing things out first.)

<!-- Feel free to add any additional description of changes below this line -->

## Testing

Start Storybook and check if the Modal is displayed properly (the border is significantly thicker if the rule isn't applied).
