### PR TITLE
ci: only respond to pushes if targetting main

### DIFF
--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -1,5 +1,9 @@
 name: Test Storybook
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   test:
     name: Test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,9 @@
 name: Unit Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Otherwise renovate PRs (which create branches on the repo before
creating PRs) will trigger the same tests twice.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
