### PR TITLE
fix: apply and simplify jest lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,15 +26,7 @@
   "overrides": [
     {
       "files": ["**/*.test.*"],
-      "extends": ["plugin:jest/recommended"],
-      "plugins": ["jest"],
-      "rules": {
-        "jest/no-disabled-tests": "warn",
-        "jest/no-focused-tests": "error",
-        "jest/no-identical-title": "error",
-        "jest/prefer-to-have-length": "warn",
-        "jest/valid-expect": "error"
-      }
+      "extends": ["plugin:jest/recommended", "plugin:jest/style"]
     }
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
   },
   "overrides": [
     {
-      "files": ["**/*.test.js"],
+      "files": ["**/*.test.*"],
       "extends": ["plugin:jest/recommended"],
       "plugins": ["jest"],
       "rules": {

--- a/src/drop-down/drop-down.test.tsx
+++ b/src/drop-down/drop-down.test.tsx
@@ -22,7 +22,7 @@ describe("<DropDownButton>", () => {
 		const item = within(unorderedList).getAllByRole("menuitem");
 		expect(unorderedList).toBeInTheDocument();
 		expect(dropdownTrigger).toBeInTheDocument();
-		expect(item.length).toBe(3);
+		expect(item).toHaveLength(3);
 	});
 
 	it("should render button with direction to up", async () => {

--- a/src/form-group/form-group.test.tsx
+++ b/src/form-group/form-group.test.tsx
@@ -17,10 +17,10 @@ describe("<FormGroup>", () => {
 		);
 
 		const element = screen.getByTestId("test-id");
-		expect(element.childNodes.length).toBe(sameNumberOfChildren);
+		expect(element.childNodes).toHaveLength(sameNumberOfChildren);
 
 		const formGroupChildren = screen.getAllByTitle("Child");
-		expect(formGroupChildren.length).toBe(sameNumberOfChildren);
+		expect(formGroupChildren).toHaveLength(sameNumberOfChildren);
 		element.childNodes.forEach((child, index) => {
 			expect(child).toBe(formGroupChildren[index]);
 		});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The rules weren't being applied to our tests, so I changed the override. Also, the recommended and style configurations have some nice defaults, so I think we can just use them until we feel a need to 
configure them. 

<!-- Feel free to add any additional description of changes below this line -->
