### PR TITLE
fix(a11y): disabled button behavior and color contrast

### DIFF
--- a/src/button/button.stories.tsx
+++ b/src/button/button.stories.tsx
@@ -1,5 +1,9 @@
+import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
+import { FormControl } from "../form-control";
+import { FormGroup } from "../form-group";
+import { ControlLabel } from "../control-label";
 import { Button } from ".";
 
 const story = {
@@ -113,6 +117,39 @@ export const AsADownloadLink: Story = {
 		href: "https://www.freecodecamp.org",
 		download: "my_file.txt",
 	},
+};
+
+const FormWithSubmitButton = () => {
+	const [username, setUsername] = useState("");
+
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setUsername(event.target.value);
+	};
+
+	const handleSubmit = () => {
+		alert("Submitted");
+	};
+
+	return (
+		<form onSubmit={handleSubmit}>
+			<FormGroup controlId="username">
+				<ControlLabel>Username</ControlLabel>
+				<FormControl
+					componentClass="input"
+					type="text"
+					onChange={handleChange}
+				/>
+			</FormGroup>
+
+			<Button type="submit" disabled={!username}>
+				Submit
+			</Button>
+		</form>
+	);
+};
+
+export const AsASubmitButton: Story = {
+	render: FormWithSubmitButton,
 };
 
 export default story;

--- a/src/button/button.test.tsx
+++ b/src/button/button.test.tsx
@@ -71,6 +71,28 @@ describe("<Button />", () => {
 		expect(onClick).not.toHaveBeenCalled();
 	});
 
+	it("should not trigger form submission if the button has `submit` type and is disabled", async () => {
+		const handleSubmit = jest.fn();
+
+		render(
+			<form onSubmit={handleSubmit}>
+				<label>
+					Username
+					<input type="text" />
+				</label>
+
+				<Button type="submit" disabled>
+					Submit
+				</Button>
+			</form>,
+		);
+
+		const button = screen.getByRole("button", { name: "Submit" });
+		await userEvent.click(button);
+
+		expect(handleSubmit).not.toHaveBeenCalled();
+	});
+
 	it("should render an anchor element if the `href` prop is defined", () => {
 		render(<Button href="https://www.freecodecamp.org">freeCodeCamp</Button>);
 

--- a/src/button/button.test.tsx
+++ b/src/button/button.test.tsx
@@ -137,3 +137,17 @@ describe("<Button />", () => {
 		expect(onClick).toHaveBeenCalledTimes(1);
 	});
 });
+
+// ------------------------------
+// Type tests
+// ------------------------------
+
+// @ts-expect-error - Button with `danger` variant cannot be disabled
+<Button variant="danger" disabled>
+	Button text
+</Button>;
+
+// @ts-expect-error - Button with `info` variant cannot be disabled
+<Button variant="info" disabled>
+	Button text
+</Button>;

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -18,9 +18,6 @@ const defaultClassNames = [
 	"active:before:border-transparent",
 	"active:before:bg-gray-900",
 	"active:before:opacity-20",
-	// Disabled state
-	"aria-disabled:cursor-not-allowed",
-	"aria-disabled:opacity-50",
 	// Focus state
 	"focus:outline-none", // Hide the default browser outline
 	"focus-visible:ring",
@@ -54,18 +51,14 @@ const computeClassNames = ({
 				"border-foreground-danger",
 				"bg-background-danger",
 				"text-foreground-danger",
-				...(disabled
-					? ["active:before:hidden"]
-					: [
-							"hover:bg-foreground-danger",
-							"hover:text-background-danger",
-							// This hover rule is redundant for the component library,
-							// but is needed to override the border color set in client's `global.css`.
-							// We can remove it once we have completely removed the CSS overrides in client.
-							"hover:border-foreground-danger",
-							"dark:hover:bg-background-danger",
-							"dark:hover:text-foreground-danger",
-						]),
+				"hover:bg-foreground-danger",
+				"hover:text-background-danger",
+				// This hover rule is redundant for the component library,
+				// but is needed to override the border color set in client's `global.css`.
+				// We can remove it once we have completely removed the CSS overrides in client.
+				"hover:border-foreground-danger",
+				"dark:hover:bg-background-danger",
+				"dark:hover:text-foreground-danger",
 			);
 			break;
 		case "info":
@@ -73,29 +66,30 @@ const computeClassNames = ({
 				"border-foreground-info",
 				"bg-background-info",
 				"text-foreground-info",
-				...(disabled
-					? ["active:before:hidden"]
-					: [
-							"hover:bg-foreground-info",
-							"hover:text-background-info",
-							// This hover rule is redundant for the component library,
-							// but is needed to override the border color set in client's `global.css`.
-							// We can remove it once we have completely removed the CSS overrides in client.
-							"hover:border-foreground-info",
-							"dark:hover:bg-background-info",
-							"dark:hover:text-foreground-info",
-						]),
+				"hover:bg-foreground-info",
+				"hover:text-background-info",
+				// This hover rule is redundant for the component library,
+				// but is needed to override the border color set in client's `global.css`.
+				// We can remove it once we have completely removed the CSS overrides in client.
+				"hover:border-foreground-info",
+				"dark:hover:bg-background-info",
+				"dark:hover:text-foreground-info",
 			);
 			break;
 		// default variant is 'primary'
 		default:
 			classNames.push(
-				"border-foreground-secondary",
 				"bg-background-quaternary",
 				"text-foreground-secondary",
 				...(disabled
-					? ["active:before:hidden"]
+					? [
+							"active:before:hidden",
+							"border-gray-450",
+							"aria-disabled:cursor-not-allowed",
+							"aria-disabled:opacity-80",
+						]
 					: [
+							"border-foreground-secondary",
 							"hover:bg-foreground-primary",
 							"hover:text-background-primary",
 							// This hover rule is redundant for the component library,
@@ -198,6 +192,11 @@ export const HeadlessButton = React.forwardRef<
 			);
 		} else {
 			return (
+				// @ts-expect-error - Type check error is expected.
+				// `disabled` can either be `boolean | undefined` or `false | undefined` depending on the union member.
+				// TypeScript can't infer the actual union member (that ties to the `variant`),
+				// so it complains about the `disabled` type being incompatible.
+				// Ref: https://github.com/Microsoft/TypeScript/issues/30518
 				<StylessButton
 					className={className}
 					onClick={onClick}

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -133,6 +133,7 @@ const StylessButton = React.forwardRef<React.ElementRef<"button">, ButtonProps>(
 		// Ref: https://css-tricks.com/making-disabled-buttons-more-inclusive/#aa-the-difference-between-disabled-and-aria-disabled
 		const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
 			if (disabled) {
+				event.preventDefault();
 				return;
 			}
 

--- a/src/button/types.ts
+++ b/src/button/types.ts
@@ -4,16 +4,34 @@ export type ButtonVariant = "primary" | "danger" | "info";
 
 export type ButtonSize = "small" | "medium" | "large";
 
-export interface ButtonProps
+interface BaseButtonProps
 	extends React.ButtonHTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
 	children: React.ReactNode;
-	variant?: ButtonVariant;
 	size?: ButtonSize;
 	onClick?: MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
 	type?: "submit" | "button";
-	disabled?: boolean;
 	block?: boolean;
 	href?: string;
 	download?: string;
 	target?: React.HTMLAttributeAnchorTarget;
 }
+
+interface PrimaryButtonProps extends BaseButtonProps {
+	variant?: "primary";
+	disabled?: boolean;
+}
+
+interface InfoButtonProps extends BaseButtonProps {
+	variant: "info";
+	disabled?: false;
+}
+
+interface DangerButtonProps extends BaseButtonProps {
+	variant: "danger";
+	disabled?: false;
+}
+
+export type ButtonProps =
+	| PrimaryButtonProps
+	| InfoButtonProps
+	| DangerButtonProps;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Issues and Context

There are two issues with the Button component, which were brought up in https://github.com/freeCodeCamp/freeCodeCamp/pull/53824#issuecomment-2018611111:
1. Button with `type="submit"` can still trigger form submission even if it's disabled
2. The text of disabled button doesn't have sufficient contrast

(1) is indeed a bug and the fix is straight forward, so I only want to discuss (2).

So if we want to reflect the disabled state of an element, we can use either the HTML `disabled` or `aria-disabled` attribute. 

With the `disabled` attribute, the element is still present in the DOM, but removed from the accessibility tree, meaning non-sighted users won't know the button is there nor its disabled state, and they also can't interact with it.

With the `aria-disabled` attribute, the users can use the keyboard to focus on the button, and can be informed about the element and its disabled state. This is the behavior I decided to go with, as the UX is much better.

However, we have been dimming the text and background color of the button is communicate the disabled state visually. This would be acceptable if the button isn't interactable, but since we want it to be interactable, we are failing the color contrast requirement.

## Approaches

To address the color contrast requirement, the most straightforward fix would be improving the contrast. We are currently using the `opacity` attribute to dim the colors, but in order to make the button look nice and accessible, we would need to play with the color combinations and not just cranking up the opacity. We also don't have colors that could be used for the disabled state of the `danger` and `info` variants, so I'd need some help here (from Ahmad) if we want to proceed with the color update.

Alternatively, I think we should consider removing the disabled state and keeping buttons enabled at all time. 
- If the user isn't allowed to perform an action, we can completely hide the button.
- If the user can only perform an action if they have fulfilled all the requirements, we can add a validation check to the button, and show a message telling the user what they have missed, or complete the action if the requirements are met.

That would help resolve the color contrast and interactivity issues, while also improving the user experience. (I think we've been assuming the users would understand why the button is disabled and how to enable it, but that might not be obvious for some).

## My Fix

I might have gone _a little_ overboard with the changes.

My fix is a mix of both approaches:
- I updated the CSS of the disabled state of the `primary` button to improve the contrast
- I set the `disabled` value of the `danger` and `info` to always `false`

Rationale: 
  - I checked /learn's `global.css` stylesheet and found that all buttons have `primary` styles when they are disabled (notice the `button` selector and the colors used in [the code](https://github.com/freeCodeCamp/freeCodeCamp/blob/086ff3633302c4702e620da99eb5454c027b1a91/client/src/components/layouts/global.css#L279-L282)), so I assume we implicitly don't support disabled state in `danger` and `info` variants (otherwise they look very different from their enabled state).
  - In /learn, there isn't any `danger` or `info` button that is used with the `disabled` prop (meaning `danger` and `info` buttons are enabled at all time).

The changes are to close down the feature that has no usages, and to move us closer to the second approach above (assuming everyone agrees with the approach).

## Screenshots

Basically instead of dimming the text and the background colors, I dim the border color to communicate the disabled state.

| | Before | After |
| --- | --- | --- |
| Light | <img width="106" alt="Screenshot 2024-04-11 at 14 31 33" src="https://github.com/freeCodeCamp/ui/assets/25715018/1c30a72e-61dd-494d-beb0-489430bf82e9"> | <img width="100" alt="Screenshot 2024-04-11 at 14 32 25" src="https://github.com/freeCodeCamp/ui/assets/25715018/b4cdda1a-12d6-4013-9621-c77265bca642"> | 
| Dark | <img width="112" alt="Screenshot 2024-04-11 at 14 31 41" src="https://github.com/freeCodeCamp/ui/assets/25715018/99e87a9b-c0cb-493f-94bb-046a2ab7a64d"> | <img width="108" alt="Screenshot 2024-04-11 at 14 32 17" src="https://github.com/freeCodeCamp/ui/assets/25715018/e02aae4e-0856-4e88-87b5-a722b752fcc2"> |

<!-- Feel free to add any additional description of changes below this line -->


