### PR TITLE
chore(eslint): enable react/forbid-dom-props rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,5 +28,18 @@
       "files": ["**/*.test.*"],
       "extends": ["plugin:jest/recommended", "plugin:jest/style"]
     }
-  ]
+  ],
+  "rules": {
+    "react/forbid-dom-props": [
+      2,
+      {
+        "forbid": [
+          {
+            "propName": "style",
+            "message": "The element should be styled using class names"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Note: The `color-system` component violates this rule so it needs to be updated, but its story needs to be resurrected first in order to test the changes (#66).

---

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR enables the `react/forbid-dom-props` rule to disallow inline styles in HTML elements. 

We already have two ways to style an element: using a CSS stylesheet and using Tailwind classes, so there is no need for inline styles. Inline styles also have high specificity and they will override the rules in our stylesheets (except for rules with `!important`), so they will make debugging CSS more challenging.

Ref: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md

## Screenshot

Screenshot of the rule in action:

<img width="777" alt="Screenshot 2024-04-12 at 14 11 16" src="https://github.com/freeCodeCamp/ui/assets/25715018/2f675c3c-72f7-4d3d-a529-78a4c1e2c446">




<!-- Feel free to add any additional description of changes below this line -->
