### PR TITLE
fix(a11y): color contrast of FormControl placeholder text

### DIFF
--- a/src/form-control/form-control.tsx
+++ b/src/form-control/form-control.tsx
@@ -9,7 +9,7 @@ import { FormControlProps } from "./types";
 // type Only relevant if componentClass is 'input'.
 let variantClass: string;
 const defaultClasses =
-	"outline-0 block w-full py-1.5 px-2.5 text-md text-foreground-primary bg-background-primary bg-none rounded-none border-1 border-solid border-background-quaternary shadow-none transition ease-in-out duration-150 focus:border-foreground-tertiary";
+	"outline-0 block w-full py-1.5 px-2.5 text-md text-foreground-primary placeholder:text-foreground-quaternary bg-background-primary bg-none rounded-none border-1 border-solid border-background-quaternary shadow-none transition ease-in-out duration-150 focus:border-foreground-tertiary";
 
 const FormControl = ({
 	componentClass,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR explicitly sets a color value to the placeholder text of the `FormControl` component, instead of relying on the browser default styles. This change is to ensure color contrast is sufficient on all browsers.

The color used for the placeholder text is `foreground-quaternary`, and the contrast ratio is as follows:

| Theme | Placeholder color | Background color | Contrast ratio |
| --- | --- | --- | --- |
| Light | #3b3b4f | #ffffff | 10.91:1 ([contrast checker](https://webaim.org/resources/contrastchecker/?fcolor=3B3B4F&bcolor=FFFFFF)) |
| Dark | #d0d0d5 | #0a0a23 | 12.64:1 ([contrast checker](https://webaim.org/resources/contrastchecker/?fcolor=D0D0D5&bcolor=0A0A23)) |

Closes #69

## Screenshot

| Theme | Screenshot |
| --- | --- |
| Light | <img width="177" alt="Screenshot 2024-04-12 at 16 14 50" src="https://github.com/freeCodeCamp/ui/assets/25715018/8d82cb4c-6577-4d36-bf35-c0cf99882ea9"> |
| Dark | <img width="194" alt="Screenshot 2024-04-12 at 16 14 43" src="https://github.com/freeCodeCamp/ui/assets/25715018/e23497a6-d94a-4694-ab2a-0d75783c5274"> |

<!-- Feel free to add any additional description of changes below this line -->
