### PR TITLE
fix: storybook static directory

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -54,4 +54,6 @@ module.exports = {
 	docs: {
 		autodocs: true,
 	},
+
+	staticDirs: [{ from: "../src/assets", to: "/assets" }],
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## Issue

I noticed that the Storybook site in production (https://opensource.freecodecamp.org/ui) doesn't have the correct fonts, even after #100.

Storybook does automagically pull the fonts into a `static/media` folder:

<img width="312" alt="Screenshot 2024-05-07 at 12 16 34" src="https://github.com/freeCodeCamp/ui/assets/25715018/45ceb239-a27f-4128-9b1a-9ddef5fa5731">

But we don't look for fonts in that path:

https://github.com/freeCodeCamp/ui/blob/7f9fc26571b1813bcea8e04fc7c0f220993cadc9/src/fonts.css#L5

## Solution

To resolve the issue, I'm adding the `staticDirs` option to the Storybook config, which asks Storybook to copy the files into the specified folder:

<img width="302" alt="Screenshot 2024-05-07 at 12 36 11" src="https://github.com/freeCodeCamp/ui/assets/25715018/9cae172c-b524-4487-b01a-a8e14fa0af92">

Notice that the `static/media` folder is still there. This appears to be the default in Storybook, and I can't seem to find a config option to remove/omit the folder.

## Reference
https://storybook.js.org/docs/configure/images-and-assets#serving-static-files-via-storybook-configuration

<!-- Feel free to add any additional description of changes below this line -->
