### PR TITLE
fix(a11y): control label text color

### DIFF
--- a/src/control-label/control-label.tsx
+++ b/src/control-label/control-label.tsx
@@ -19,7 +19,7 @@ export const ControlLabel = ({
 
 	const labelStyle = validationState
 		? validationLabel[validationState]
-		: undefined;
+		: "text-foreground-primary";
 	const screenOnlyClass = srOnly ? "sr-only" : undefined;
 	const defaultClasses = [labelStyle, screenOnlyClass, className].join(" ");
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The `ControlLabel` component doesn't have text color set, so it has been using the default color (black), which makes the text unreadable in dark theme:

<img width="155" alt="Screenshot 2024-05-07 at 23 41 07" src="https://github.com/freeCodeCamp/ui/assets/25715018/52b66c0b-b370-41d6-b48d-db835fc4882f">

The issue can be seen here: https://opensource.freecodecamp.org/ui/?path=/story/components-formgroup--default&globals=backgrounds.value:!hex(0a0a23).

This PR adds a default text color to the component.

---

The root cause is actually a little deeper.
- ControlLabel doesn't have text color specified, so it falls back to the global `body` style
- `body` has `color` set to `secondary-color`
  - https://github.com/freeCodeCamp/ui/blob/5317d855eb8e9c1f44a5a20db91a059850e95dc3/src/global-element-styles.css#L383-L388
- But we don't have that token in our color list: https://github.com/freeCodeCamp/ui/blob/main/src/colors.css

We are removing `global-element-styles.css` as part of #61 so I don't bother updating the file.

Also, the issue luckily doesn't affect /learn. The element does need to fall back to the `body` text color, which is also `secondary-color`, but this token exists there: https://github.com/freeCodeCamp/freeCodeCamp/blob/50d7f03763e7d64690391bc7a004eccbdd75156d/client/src/components/layouts/variables.css#L43.

## Screenshot

| Light | Dark |
| --- | --- |
| <img width="160" alt="Screenshot 2024-05-07 at 23 40 39" src="https://github.com/freeCodeCamp/ui/assets/25715018/c7656c17-3516-4c46-a422-f324c5c0420b"> | <img width="175" alt="Screenshot 2024-05-07 at 23 40 33" src="https://github.com/freeCodeCamp/ui/assets/25715018/42e7eb5c-c0b1-47b4-a405-5e8291068c40"> |

<!-- Feel free to add any additional description of changes below this line -->
