### PR TITLE
fix: exclude fonts.css from the base stylesheet

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,7 @@ import React from "react";
 import "../src/normalize.css";
 import "../src/global-element-styles.css";
 import "../src/base.css";
+import "../src/fonts.css";
 
 export const parameters = {
 	controls: {

--- a/src/base.css
+++ b/src/base.css
@@ -1,5 +1,4 @@
 @import "./colors.css";
-@import "./fonts.css";
 
 @tailwind base;
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`fonts.css` references the font files in `/assets`. This works with the component library itself, but is broken if used in a consumer project as the fonts are not included in the library bundle.

https://github.com/freeCodeCamp/ui/blob/c754ceefb6daa02ed1a7d784cc49260a0b414cf7/src/fonts.css#L5

I'm keeping the `fonts.css` out of `base.css` for now, and not export the `fonts.css` out for consumption. I'll add it back into `base.css` via #123, to export the stylesheet together with the font files.

<!-- Feel free to add any additional description of changes below this line -->
