### PR TITLE
fix(a11y): increase the opacity of input placeholder

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -46,7 +46,7 @@
 	/* https://github.com/tailwindlabs/tailwindcss/blob/3.4/src/css/preflight.css#L335 */
 	input::placeholder,
 	textarea::placeholder {
-		@apply text-foreground-quaternary opacity-70;
+		@apply text-foreground-quaternary opacity-80;
 	}
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The placeholder text of the /learn search bar doesn't have a sufficient contrast ratio. This is because the opacity is a little to low (0.7). This PR bumps the opacity value to address that.

This change will address https://github.com/freeCodeCamp/freeCodeCamp/issues/55711 (after a version bump, of course).

<!-- Feel free to add any additional description of changes below this line -->
