### PR TITLE
docs: add stories for how PrismFormatted handles long lines

### DIFF
--- a/src/prism-formatted/prism-formatted.stories.tsx
+++ b/src/prism-formatted/prism-formatted.stories.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import { PrismFormatted } from "./prism-formatted";
@@ -63,6 +64,52 @@ export const WithLineNumbers: Story = {
 	</code></pre>
 	<p>Which line/lines should be surrounded by <code>try</code> block?</p>"
 />`,
+			},
+		},
+	},
+};
+
+export const WithLongLineOfCode: Story = {
+	args: {
+		text: `<pre><code class="language-html"><p>This story shows how PrismFormatted displays a long line of code. This line should not wrap to a new line, but instead, the overflow content is clipped and can be scrolled into view.</p></code></pre>`,
+		getCodeBlockAriaLabel: (codeName) => `${codeName} code example`,
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `<PrismFormatted
+  getCodeBlockAriaLabel={codeName => \`\${codeName} code example\`}
+  text={\`<pre><code class="language-html"><p>This story shows how PrismFormatted displays a long line of code. This line should not wrap to a new line, but instead, the overflow content is clipped and can be scrolled into view.</p></code></pre>\`}
+/>`,
+			},
+		},
+	},
+};
+
+export const InsideDisclosureElement: Story = {
+	decorators: [
+		(Story) => (
+			<details>
+				<summary>Example code</summary>
+				<Story />
+			</details>
+		),
+	],
+	args: {
+		text: `<pre><code class="language-html"><p>This story shows how PrismFormatted displays a long line of code when it's rendered inside a disclosure element. This line should not wrap to a new line, but instead, the overflow content is clipped and can be scrolled into view.</p></code></pre>`,
+		getCodeBlockAriaLabel: (codeName) => `${codeName} code example`,
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `<details>
+  <summary>Example code</summary>
+
+  <PrismFormatted
+    getCodeBlockAriaLabel={codeName => \`\${codeName} code example\`}
+    text={\`<pre><code class="language-html"><p>This story shows how PrismFormatted displays a long line of code when it's rendered inside a disclosure element. This line should not wrap to a new line, but instead, the overflow content is clipped and can be scrolled into view.</p></code></pre>\`}
+	/>
+</details>`,
 			},
 		},
 	},


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was tweaking PrismFormatted storybook examples to check if the changes in https://github.com/freeCodeCamp/freeCodeCamp/pull/56119 should be ported over (in other words, if the issue is in PrismFormatted or just in /learn). And since I already made the storybook changes, I thought I should just check them in since they could be useful for sanity check.

The two examples I'm adding are:
- When `PrismFormatted` receives a long string
- When `PrismFormatted` receives a long string, and the component is rendered inside a `details` element

In both cases, the string is rendered as a single line and doesn't wrap (as we expect), so I think the issue isn't in the PrismFormatted component.

## Screenshot

<details>
  <summary>Screenshot</summary>
<img width="1049" alt="Screenshot 2024-09-17 at 01 19 45" src="https://github.com/user-attachments/assets/1db0d813-9fce-40a0-af58-3d3c570229e9">
</details>

<!-- Feel free to add any additional description of changes below this line -->
