### PR TITLE
fix: allow QuizQuestion to render PrismFormatted in answer label

### DIFF
--- a/src/quiz-question/quiz-question.stories.tsx
+++ b/src/quiz-question/quiz-question.stories.tsx
@@ -72,7 +72,7 @@ export const Default: Story = {
 	},
 };
 
-export const WithCodeInQuestionText: Story = {
+export const WithCodeInQuestionAndAnswerText: Story = {
 	render: QuizQuestionComp,
 	args: {
 		question: (
@@ -89,7 +89,17 @@ print(cel)
 			/>
 		),
 		answers: [
-			{ label: "Option 1", value: 1 },
+			{
+				label: (
+					<PrismFormatted
+						text={`<pre><code class="language-html"><p>Option 1</p>
+<p>Lorem ipsum</p>
+</code></pre>`}
+						getCodeBlockAriaLabel={(codeName) => `${codeName} code example`}
+					/>
+				),
+				value: 1,
+			},
 			{ label: "Option 2", value: 2 },
 			{ label: "Option 3", value: 3 },
 		],
@@ -115,7 +125,17 @@ print(cel)
           getCodeBlockAriaLabel={(codeName) => \`\${codeName} code example\`}
       />}
       answers={[
-        { label: "Option 1", value: 1 },
+        { 
+          label: (
+            <PrismFormatted
+              text={\`<pre><code class="language-html"><p>Option 1</p>
+<p>Lorem ipsum</p>
+</code></pre>\`}
+              getCodeBlockAriaLabel={(codeName) => \`\${codeName} code example\`}
+	          />
+          ), 
+          value: 1,
+        },
         { label: "Option 2", value: 2 },
         { label: "Option 3", value: 3 }
       ]}

--- a/src/quiz-question/types.ts
+++ b/src/quiz-question/types.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 
 export interface QuizQuestionAnswer {
-	label: string;
+	label: ReactNode;
 	value: number;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The `label` of quiz question answer is current accepting string only, but the type should be ReactNode to allow rendering the label with PrismFormatted.

I'm updating a Storybook demo to cover this case as well.

<details>
<summary>Screenshot</summary>

<img width="1039" alt="Screenshot 2024-09-19 at 05 43 44" src="https://github.com/user-attachments/assets/d119dfb0-00df-45b7-b0af-f1c5a6b70c4b">
</details>

<!-- Feel free to add any additional description of changes below this line -->
