### PR TITLE
fix: rendering of quiz question with code

### DIFF
--- a/src/quiz-question/quiz-question.stories.tsx
+++ b/src/quiz-question/quiz-question.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof QuizQuestion>;
 
 type QuizQuestionCompProps = Pick<
 	QuizQuestionProps,
-	"question" | "answers" | "disabled" | "validation"
+	"question" | "answers" | "disabled" | "validation" | "position"
 >;
 
 const QuizQuestionComp = ({
@@ -23,6 +23,7 @@ const QuizQuestionComp = ({
 	answers,
 	disabled,
 	validation,
+	position,
 }: QuizQuestionCompProps) => {
 	const [answer, setAnswer] = useState<QuizQuestionProps["selectedAnswer"]>();
 
@@ -34,6 +35,7 @@ const QuizQuestionComp = ({
 			validation={validation}
 			onChange={(newAnswer) => setAnswer(newAnswer)}
 			selectedAnswer={answer}
+			position={position}
 		/>
 	);
 };
@@ -250,6 +252,66 @@ export const Incorrect: Story = {
       onChange={(newAnswer) => setAnswer(newAnswer)}
       selectedAnswer={answer}
       validation={{ state: "incorrect", message: "Incorrect." }}
+    />
+  );
+}`,
+			},
+		},
+	},
+};
+
+export const WithPosistion: Story = {
+	render: QuizQuestionComp,
+	args: {
+		question: (
+			<PrismFormatted
+				text={`<p>Given the following code:</p>
+<pre><code class="language-python">temp = "5 degrees"
+cel = 0
+fahr = float(temp)
+cel = (fahr - 32.0) * 5.0 / 9.0
+print(cel)
+</code></pre>
+<p>Which line/lines should be surrounded by <code>try</code> block?</p>`}
+				getCodeBlockAriaLabel={(codeName) => `${codeName} code example`}
+			/>
+		),
+		answers: [
+			{ label: "Option 1", value: 1 },
+			{ label: "Option 2", value: 2 },
+			{ label: "Option 3", value: 3 },
+		],
+		position: 1,
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `const App = () => {
+  const [answer, setAnswer] = useState();
+
+  return (
+    <QuizQuestion
+      question={
+        <PrismFormatted
+          text={\`<p>Given the following code:</p>
+<pre><code class="language-python">temp = "5 degrees"
+cel = 0
+fahr = float(temp)
+cel = (fahr - 32.0) * 5.0 / 9.0
+print(cel)
+</code></pre>
+<p>Which line/lines should be surrounded by <code>try</code> block?</p>\`}
+          getCodeBlockAriaLabel={(codeName) => \`\${codeName} code example\`}
+       />
+      }
+      answers={[
+        { label: "Option 1", value: 1 },
+        { label: "Option 2", value: 2 },
+        { label: "Option 3", value: 3 }
+      ]}
+      onChange={(newAnswer) => setAnswer(newAnswer)}
+      selectedAnswer={answer}
+      position={1}
     />
   );
 }`,

--- a/src/quiz-question/quiz-question.tsx
+++ b/src/quiz-question/quiz-question.tsx
@@ -22,8 +22,10 @@ const QuestionText = ({
 	}
 
 	return (
-		<span className="text-foreground-primary">
-			{`${position}. ${question}`}
+		<span className="text-foreground-primary flex">
+			<span>{position}.</span>
+			&nbsp;
+			{question}
 		</span>
 	);
 };

--- a/src/quiz-question/types.ts
+++ b/src/quiz-question/types.ts
@@ -12,7 +12,8 @@ export interface QuizQuestionValidation {
 
 export interface QuizQuestionProps {
 	/**
-	 * Question text
+	 * Question text, can be plain text or contain code.
+	 * If the question text contains code, use the PrismFormatted component to ensure the code is rendered correctly.
 	 */
 	question: ReactNode;
 

--- a/src/quiz/types.ts
+++ b/src/quiz/types.ts
@@ -1,6 +1,7 @@
 import type {
 	QuizQuestionAnswer,
 	QuizQuestionValidation,
+	QuizQuestionProps,
 } from "../quiz-question";
 
 // This interface is a subset of QuizQuestionProps.
@@ -10,9 +11,10 @@ import type {
 // without being overriden by the `disabled` prop of the individual question.
 export interface Question {
 	/**
-	 * Question text
+	 * Question text, can be plain text or contain code.
+	 * If the question text contains code, use the PrismFormatted component to ensure the code is rendered correctly.
 	 */
-	question: string;
+	question: QuizQuestionProps["question"];
 
 	/**
 	 * Answer options


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Yet another fix for quiz stuff with code display 😞 

I was testing https://github.com/freeCodeCamp/freeCodeCamp/pull/56163 and found that `QuizQuestion` isn't displaying question text correct if the text is a node (rendered with PrismFormatted) _and_ has `position` (the number before the question text).

<details>

<summary>Screenshot of quiz question with the issue</summary>

<img width="767" alt="Screenshot 2024-09-20 at 14 16 51" src="https://github.com/user-attachments/assets/8be94e13-9a2d-4b62-a823-7598ccecdd31">

</details>

I didn't notice the issue because I didn't have a Storybook demo for this case, so I'm adding a new demo for that along with the fix.

<details>

<summary>Screenshot of quiz question with the fix</summary>

<img width="1053" alt="Screenshot 2024-09-20 at 14 23 09" src="https://github.com/user-attachments/assets/989822a9-1cec-473f-852a-1f4d8d120a03">

</details>

<!-- Feel free to add any additional description of changes below this line -->
