### PR TITLE
fix: quiz validation icon alignment

### DIFF
--- a/src/quiz-question/quiz-question.tsx
+++ b/src/quiz-question/quiz-question.tsx
@@ -18,11 +18,11 @@ const QuestionText = ({
 	position?: number;
 }) => {
 	if (position == null) {
-		return <span className="text-foreground-primary">{question}</span>;
+		return <span className="text-foreground-primary text-md">{question}</span>;
 	}
 
 	return (
-		<span className="text-foreground-primary flex">
+		<span className="text-foreground-primary text-md flex">
 			<span>{position}.</span>
 			&nbsp;
 			{question}
@@ -37,17 +37,25 @@ const ValidationIcon = ({
 }) => {
 	const { state, message } = validation;
 
+	// Add top and bottom margins to the icon in order to horizontally align it with the first line of question text.
+	// The math is as follows:
+	// top/bottom margin = (text font size * text line height - icon height) / 2
+	// Note: The text font size and text line height values need to match the ones specified in tailwind.config.js
+	const iconMarginClass = "my-[calc((18px*1.42857143-14px)/2)]";
+
 	return state === "correct" ? (
 		<FontAwesomeIcon
 			icon={faCheck}
-			className="text-background-success me-[8px]"
+			size="sm"
+			className={`text-background-success me-[8px] ${iconMarginClass}`}
 			aria-label={message}
 			aria-hidden={false}
 		/>
 	) : (
 		<FontAwesomeIcon
 			icon={faXmark}
-			className="text-background-danger me-[8px]"
+			size="sm"
+			className={`text-background-danger me-[8px] ${iconMarginClass}`}
 			aria-label={message}
 			aria-hidden={false}
 		/>
@@ -90,7 +98,7 @@ export const QuizQuestion = ({
 			// Ref: https://react.dev/reference/react-dom/components/input#im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled
 			value={selectedAnswer ?? null}
 		>
-			<RadioGroup.Label className="block mb-[20px]">
+			<RadioGroup.Label className="flex mb-[20px]">
 				{validation && <ValidationIcon validation={validation} />}
 				<QuestionText question={question} position={position} />
 			</RadioGroup.Label>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Fixes an issue where the validation icon isn't on the same line as the question text
- Also makes the icon horizontally aligned with the first line of question text.

## Screenshot

| Before | After |
| --- | --- |
| <img width="463" alt="Screenshot 2024-09-26 at 02 51 18" src="https://github.com/user-attachments/assets/3abc4952-7153-4ca9-b113-9ccee8236e53"> | <img width="483" alt="Screenshot 2024-09-26 at 02 50 57" src="https://github.com/user-attachments/assets/0ca6d24c-55ef-49aa-b370-f3e3a76566f2"> |

<!-- Feel free to add any additional description of changes below this line -->
