### PR TITLE
fix: move validation status to the selected answer

### DIFF
--- a/src/quiz-question/answer.tsx
+++ b/src/quiz-question/answer.tsx
@@ -49,6 +49,8 @@ const radioOptionDefaultClasses = [
 	"focus:outline-none",
 	"cursor-pointer",
 	"p-[20px]",
+	"flex",
+	"items-center",
 ];
 
 const radioWrapperDefaultClasses = [
@@ -120,14 +122,8 @@ export const Answer = ({
 	const getRadioOptionCls = () => {
 		const cls = [...radioOptionDefaultClasses];
 
-		if (disabled) cls.push("aria-disabled:cursor-not-allowed");
-		return cls.join(" ");
-	};
-
-	const getRadioLabelCls = () => {
-		const cls = ["flex", "items-center"];
-
-		if (disabled) cls.push("opacity-80");
+		if (disabled)
+			cls.push("aria-disabled:cursor-not-allowed", "aria-disabled:opacity-80");
 		return cls.join(" ");
 	};
 
@@ -139,12 +135,12 @@ export const Answer = ({
 				className={getRadioOptionCls()}
 			>
 				{({ active }) => (
-					<div className={getRadioLabelCls()}>
+					<>
 						<RadioIcon active={active} checked={!!checked} />
 						<RadioGroup.Label className="m-0 text-foreground-primary">
 							{label}
 						</RadioGroup.Label>
-					</div>
+					</>
 				)}
 			</RadioGroup.Option>
 			{checked && validation && (

--- a/src/quiz-question/answer.tsx
+++ b/src/quiz-question/answer.tsx
@@ -147,16 +147,16 @@ export const Answer = ({
 					</div>
 				)}
 			</RadioGroup.Option>
-			{/* Remove the default bottom margin of the validation message `p`,
-					and apply a bottom padding of 20px to match the space between the radio icon and the top of the container */}
-			<div className="ps-[20px] pb-[20px] [&>p:last-child]:m-0">
-				{checked && validation && (
+			{checked && validation && (
+				// Remove the default bottom margin of the validation message `p`,
+				// and apply a bottom padding of 20px to match the top padding of RadioGroup.Option
+				<div className="ps-[20px] pb-[20px] [&>p:last-child]:m-0">
 					<ValidationMessage
 						state={validation.state}
 						message={validation.message}
 					/>
-				)}
-			</div>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/src/quiz-question/answer.tsx
+++ b/src/quiz-question/answer.tsx
@@ -104,22 +104,34 @@ export const Answer = ({
 	checked,
 	validation,
 }: AnswerProps) => {
-	const radioOptionCls = [
-		...radioOptionDefaultClasses,
-		...(disabled
-			? ["aria-disabled:cursor-not-allowed", "aria-disabled:opacity-80"]
-			: []),
-	];
+	const getRadioOptionCls = () => {
+		const cls = [...radioOptionDefaultClasses];
+
+		if (disabled) cls.push("aria-disabled:cursor-not-allowed");
+		if (checked && validation?.state === "correct")
+			cls.push("bg-foreground-success");
+		if (checked && validation?.state === "incorrect")
+			cls.push("bg-foreground-danger");
+
+		return cls.join(" ");
+	};
+
+	const getRadioLabelCls = () => {
+		const cls = ["flex", "items-center"];
+
+		if (disabled) cls.push("opacity-80");
+		return cls.join(" ");
+	};
 
 	return (
 		<RadioGroup.Option
 			key={value}
 			value={value}
-			className={radioOptionCls.join(" ")}
+			className={getRadioOptionCls()}
 		>
 			{({ active }) => (
 				<>
-					<div className="flex items-center">
+					<div className={getRadioLabelCls()}>
 						<RadioIcon active={active} checked={!!checked} />
 						<RadioGroup.Label className="m-0 text-foreground-primary">
 							{label}
@@ -128,12 +140,10 @@ export const Answer = ({
 					{checked && validation && (
 						<>
 							<Spacer size="s" />
-							<div>
-								<ValidationMessage
-									state={validation.state}
-									message={validation.message}
-								/>
-							</div>
+							<ValidationMessage
+								state={validation.state}
+								message={validation.message}
+							/>
 						</>
 					)}
 				</>

--- a/src/quiz-question/answer.tsx
+++ b/src/quiz-question/answer.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { RadioGroup } from "@headlessui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
 
-import { type QuizQuestionAnswer } from "./types";
+import { QuizQuestionValidation, type QuizQuestionAnswer } from "./types";
+import { Spacer } from "../spacer";
 
 interface AnswerProps extends QuizQuestionAnswer {
 	checked?: boolean;
 	disabled?: boolean;
+	validation?: QuizQuestionValidation;
 }
 
 const radioIconDefaultClasses = [
@@ -46,7 +50,7 @@ const radioOptionDefaultClasses = [
 	"focus:outline-none",
 	"cursor-pointer",
 	"flex",
-	"items-center",
+	"flex-col",
 	"p-[20px]",
 	"border-x-4",
 	"border-t-4",
@@ -73,7 +77,33 @@ const RadioIcon = ({
 	return <span className={radioCls.join(" ")}></span>;
 };
 
-export const Answer = ({ value, label, disabled, checked }: AnswerProps) => {
+const ValidationMessage = ({ state, message }: QuizQuestionValidation) => {
+	return state === "correct" ? (
+		<p className="text-background-success">
+			<FontAwesomeIcon
+				icon={faCheck}
+				className="text-background-success me-[8px]"
+			/>
+			{message}
+		</p>
+	) : (
+		<p className="text-background-danger">
+			<FontAwesomeIcon
+				icon={faXmark}
+				className="text-background-danger me-[8px]"
+			/>
+			{message}
+		</p>
+	);
+};
+
+export const Answer = ({
+	value,
+	label,
+	disabled,
+	checked,
+	validation,
+}: AnswerProps) => {
 	const radioOptionCls = [
 		...radioOptionDefaultClasses,
 		...(disabled
@@ -89,10 +119,23 @@ export const Answer = ({ value, label, disabled, checked }: AnswerProps) => {
 		>
 			{({ active }) => (
 				<>
-					<RadioIcon active={active} checked={!!checked} />
-					<RadioGroup.Label className="m-0 text-foreground-primary">
-						{label}
-					</RadioGroup.Label>
+					<div className="flex items-center">
+						<RadioIcon active={active} checked={!!checked} />
+						<RadioGroup.Label className="m-0 text-foreground-primary">
+							{label}
+						</RadioGroup.Label>
+					</div>
+					{checked && validation && (
+						<>
+							<Spacer size="s" />
+							<div>
+								<ValidationMessage
+									state={validation.state}
+									message={validation.message}
+								/>
+							</div>
+						</>
+					)}
 				</>
 			)}
 		</RadioGroup.Option>

--- a/src/quiz-question/answer.tsx
+++ b/src/quiz-question/answer.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
 
 import { QuizQuestionValidation, type QuizQuestionAnswer } from "./types";
-import { Spacer } from "../spacer";
 
 interface AnswerProps extends QuizQuestionAnswer {
 	checked?: boolean;
@@ -49,9 +48,12 @@ const radioOptionDefaultClasses = [
 	// which highlights the entire option div while we only want to highlight the radio icon.
 	"focus:outline-none",
 	"cursor-pointer",
+	"p-[20px]",
+];
+
+const radioWrapperDefaultClasses = [
 	"flex",
 	"flex-col",
-	"p-[20px]",
 	"border-x-4",
 	"border-t-4",
 	"last:border-b-4",
@@ -104,15 +106,21 @@ export const Answer = ({
 	checked,
 	validation,
 }: AnswerProps) => {
-	const getRadioOptionCls = () => {
-		const cls = [...radioOptionDefaultClasses];
+	const getRadioWrapperCls = () => {
+		const cls = [...radioWrapperDefaultClasses];
 
-		if (disabled) cls.push("aria-disabled:cursor-not-allowed");
 		if (checked && validation?.state === "correct")
 			cls.push("bg-foreground-success");
 		if (checked && validation?.state === "incorrect")
 			cls.push("bg-foreground-danger");
 
+		return cls.join(" ");
+	};
+
+	const getRadioOptionCls = () => {
+		const cls = [...radioOptionDefaultClasses];
+
+		if (disabled) cls.push("aria-disabled:cursor-not-allowed");
 		return cls.join(" ");
 	};
 
@@ -124,30 +132,31 @@ export const Answer = ({
 	};
 
 	return (
-		<RadioGroup.Option
-			key={value}
-			value={value}
-			className={getRadioOptionCls()}
-		>
-			{({ active }) => (
-				<>
+		<div className={getRadioWrapperCls()}>
+			<RadioGroup.Option
+				key={value}
+				value={value}
+				className={getRadioOptionCls()}
+			>
+				{({ active }) => (
 					<div className={getRadioLabelCls()}>
 						<RadioIcon active={active} checked={!!checked} />
 						<RadioGroup.Label className="m-0 text-foreground-primary">
 							{label}
 						</RadioGroup.Label>
 					</div>
-					{checked && validation && (
-						<>
-							<Spacer size="s" />
-							<ValidationMessage
-								state={validation.state}
-								message={validation.message}
-							/>
-						</>
-					)}
-				</>
-			)}
-		</RadioGroup.Option>
+				)}
+			</RadioGroup.Option>
+			{/* Remove the default bottom margin of the validation message `p`,
+					and apply a bottom padding of 20px to match the space between the radio icon and the top of the container */}
+			<div className="ps-[20px] pb-[20px] [&>p:last-child]:m-0">
+				{checked && validation && (
+					<ValidationMessage
+						state={validation.state}
+						message={validation.message}
+					/>
+				)}
+			</div>
+		</div>
 	);
 };

--- a/src/quiz-question/quiz-question.stories.tsx
+++ b/src/quiz-question/quiz-question.stories.tsx
@@ -13,19 +13,16 @@ const story = {
 
 type Story = StoryObj<typeof QuizQuestion>;
 
-type QuizQuestionCompProps = Pick<
-	QuizQuestionProps,
-	"question" | "answers" | "disabled" | "validation" | "position"
->;
-
 const QuizQuestionComp = ({
 	question,
-	answers,
+	answers = [],
 	disabled,
 	validation,
 	position,
-}: QuizQuestionCompProps) => {
-	const [answer, setAnswer] = useState<QuizQuestionProps["selectedAnswer"]>();
+	selectedAnswer,
+}: Partial<QuizQuestionProps>) => {
+	const [answer, setAnswer] =
+		useState<QuizQuestionProps["selectedAnswer"]>(selectedAnswer);
 
 	return (
 		<QuizQuestion
@@ -275,6 +272,8 @@ export const Correct: Story = {
 			{ label: "Option 3", value: 3 },
 		],
 		validation: { state: "correct", message: "Correct." },
+		selectedAnswer: 1,
+		disabled: true,
 	},
 	parameters: {
 		docs: {
@@ -293,6 +292,8 @@ export const Correct: Story = {
       onChange={(newAnswer) => setAnswer(newAnswer)}
       selectedAnswer={answer}
       validation={{ state: "correct", message: "Correct." }}
+			selectedAnswer: 1,
+			disabled: true
     />
   );
 }`,
@@ -311,6 +312,8 @@ export const Incorrect: Story = {
 			{ label: "Option 3", value: 3 },
 		],
 		validation: { state: "incorrect", message: "Incorrect." },
+		selectedAnswer: 1,
+		disabled: true,
 	},
 	parameters: {
 		docs: {
@@ -329,6 +332,8 @@ export const Incorrect: Story = {
       onChange={(newAnswer) => setAnswer(newAnswer)}
       selectedAnswer={answer}
       validation={{ state: "incorrect", message: "Incorrect." }}
+			selectedAnswer: 1,
+			disabled: true
     />
   );
 }`,

--- a/src/quiz-question/quiz-question.test.tsx
+++ b/src/quiz-question/quiz-question.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 import { QuizQuestion } from "./quiz-question";
 import userEvent from "@testing-library/user-event";
@@ -123,12 +123,12 @@ describe("<QuizQuestion />", () => {
 					state: "correct",
 					message: "Correct.",
 				}}
+				selectedAnswer={1}
 			/>,
 		);
 
-		expect(
-			screen.getByRole("radiogroup", { name: "Correct. Lorem ipsum" }),
-		).toBeInTheDocument();
+		const radioGroup = screen.getByRole("radiogroup", { name: "Lorem ipsum" });
+		expect(within(radioGroup).getByText("Correct.")).toBeInTheDocument();
 	});
 
 	it("should render the incorrect state properly", () => {
@@ -144,12 +144,12 @@ describe("<QuizQuestion />", () => {
 					state: "incorrect",
 					message: "Incorrect.",
 				}}
+				selectedAnswer={1}
 			/>,
 		);
 
-		expect(
-			screen.getByRole("radiogroup", { name: "Incorrect. Lorem ipsum" }),
-		).toBeInTheDocument();
+		const radioGroup = screen.getByRole("radiogroup", { name: "Lorem ipsum" });
+		expect(within(radioGroup).getByText("Incorrect.")).toBeInTheDocument();
 	});
 
 	it("should render the question position properly", () => {

--- a/src/quiz-question/quiz-question.tsx
+++ b/src/quiz-question/quiz-question.tsx
@@ -1,13 +1,7 @@
 import React, { ReactNode } from "react";
 import { RadioGroup } from "@headlessui/react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
 
-import type {
-	QuizQuestionValidation,
-	QuizQuestionAnswer,
-	QuizQuestionProps,
-} from "./types";
+import type { QuizQuestionAnswer, QuizQuestionProps } from "./types";
 import { Answer } from "./answer";
 
 const QuestionText = ({
@@ -27,30 +21,6 @@ const QuestionText = ({
 			&nbsp;
 			{question}
 		</span>
-	);
-};
-
-const ValidationIcon = ({
-	validation,
-}: {
-	validation: QuizQuestionValidation;
-}) => {
-	const { state, message } = validation;
-
-	return state === "correct" ? (
-		<FontAwesomeIcon
-			icon={faCheck}
-			className="text-background-success me-[8px]"
-			aria-label={message}
-			aria-hidden={false}
-		/>
-	) : (
-		<FontAwesomeIcon
-			icon={faXmark}
-			className="text-background-danger me-[8px]"
-			aria-label={message}
-			aria-hidden={false}
-		/>
 	);
 };
 
@@ -91,7 +61,6 @@ export const QuizQuestion = ({
 			value={selectedAnswer ?? null}
 		>
 			<RadioGroup.Label className="block mb-[20px]">
-				{validation && <ValidationIcon validation={validation} />}
 				<QuestionText question={question} position={position} />
 			</RadioGroup.Label>
 
@@ -102,6 +71,7 @@ export const QuizQuestion = ({
 					label={label}
 					checked={selectedAnswer === value}
 					disabled={disabled}
+					validation={validation}
 				/>
 			))}
 		</RadioGroup>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The QuizQuestion validation status is currently displayed next to the question text, but it is currently having an alignment issue. #339 was created to address the issue, but we wanted to take this opportunity to revisit how the status should be communicated (because displaying the icon alone is too subtle).

This PR is an alternative, in which the validation status is moved into the selected answer, and the background of the selected answer is changed based on the validation status.

## Screenshot

<details>
  <summary>Before</summary>

  <img width="463" alt="Screenshot 2024-09-26 at 02 51 18" src="https://github.com/user-attachments/assets/3abc4952-7153-4ca9-b113-9ccee8236e53">
</details>

<details>
  <summary>After</summary>

|  | Light | Dark |
| --- | --- | --- |
| Correct | <img width="1040" alt="Screenshot 2024-10-08 at 03 44 58" src="https://github.com/user-attachments/assets/6b131ea4-f15a-44b0-9e1c-ee8f52864429"> | <img width="1035" alt="Screenshot 2024-10-08 at 03 34 04" src="https://github.com/user-attachments/assets/6a554fab-54e5-4390-ae9b-c4fd1df03042"> | 
| Incorrect | <img width="1032" alt="Screenshot 2024-10-08 at 03 44 50" src="https://github.com/user-attachments/assets/6ac26222-9238-45d1-a7a2-c34803538942"> | <img width="1036" alt="Screenshot 2024-10-08 at 03 34 11" src="https://github.com/user-attachments/assets/1e178269-ef24-4542-9b87-1377686c8c3a"> |
</details>


<!-- Feel free to add any additional description of changes below this line -->
