### PR TITLE
feat: allow PrismFormatted to be collapsible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,5 +29,8 @@
       "files": ["**/*.test.*"],
       "extends": ["plugin:jest/recommended", "plugin:jest/style"]
     }
-  ]
+  ],
+  "rules": {
+    "no-mixed-spaces-and-tabs": ["error", "smart-tabs"]
+  }
 }

--- a/src/prism-formatted/prism-formatted.stories.tsx
+++ b/src/prism-formatted/prism-formatted.stories.tsx
@@ -90,7 +90,7 @@ export const InsideDisclosureElement: Story = {
 	decorators: [
 		(Story) => (
 			<details>
-				<summary>Example code</summary>
+				<summary className="text-foreground-primary">Example code</summary>
 				<Story />
 			</details>
 		),
@@ -101,6 +101,10 @@ export const InsideDisclosureElement: Story = {
 	},
 	parameters: {
 		docs: {
+			description: {
+				story:
+					"This story shows how PrismFormatted displays a long line of code when it's rendered inside a disclosure element. The text content should not wrap to a new line, but instead, the overflow content is clipped and can be scrolled into view.",
+			},
 			source: {
 				code: `<details>
   <summary>Example code</summary>
@@ -110,6 +114,31 @@ export const InsideDisclosureElement: Story = {
     text={\`<pre><code class="language-html"><p>This story shows how PrismFormatted displays a long line of code when it's rendered inside a disclosure element. This line should not wrap to a new line, but instead, the overflow content is clipped and can be scrolled into view.</p></code></pre>\`}
 	/>
 </details>`,
+			},
+		},
+	},
+};
+
+export const Collapsible: Story = {
+	args: {
+		text: `<section><p>An <code>if</code> statement allows you to run a block of code only when a condition is met. It uses the following syntax:</p><pre><code class="language-js">if (condition) {
+  logic
+}</code></pre></section>`,
+		getCodeBlockAriaLabel: (codeName) => `${codeName} code example`,
+		isCollapsible: true,
+		disclosureLabel: "Example",
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `<PrismFormatted
+  isCollapsible
+  disclosureLabel="Example"
+  getCodeBlockAriaLabel={codeName => \`\${codeName} code example\`}
+  text={\`<section><p>An <code>if</code> statement allows you to run a block of code only when a condition is met. It uses the following syntax:</p><pre><code class="language-js">if (condition) {
+  logic
+  }</code></pre></section>\`}
+/>`,
 			},
 		},
 	},

--- a/src/prism-formatted/prism-formatted.test.tsx
+++ b/src/prism-formatted/prism-formatted.test.tsx
@@ -114,4 +114,80 @@ describe("PrismFormatted", () => {
 			3, // Each `span` is a line number, and the provided code block has 3 lines.
 		);
 	});
+
+	it("should be rendered within a disclosure element if `isCollapsible` is `true`", () => {
+		render(
+			<PrismFormatted
+				getCodeBlockAriaLabel={getCodeBlockAriaLabel}
+				text="<section><pre><code class='language-js'>Foo</code></pre></section>"
+				isCollapsible
+				disclosureLabel="Code snippet"
+			/>,
+		);
+
+		const detailsEl = screen.getByRole("group");
+
+		expect(detailsEl).toBeInTheDocument();
+		expect(within(detailsEl).getByText("Code snippet")).toBeInTheDocument();
+		expect(
+			within(detailsEl).getByRole("region", {
+				name: "JavaScript code example",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("should not be rendered within a disclosure element if the text content doesn't have a `pre`", () => {
+		render(
+			<PrismFormatted
+				getCodeBlockAriaLabel={getCodeBlockAriaLabel}
+				text="<section><code>Foo</code></section>"
+				isCollapsible
+				disclosureLabel="Code snippet"
+			/>,
+		);
+
+		expect(screen.queryByRole("group")).not.toBeInTheDocument();
+		expect(screen.queryByText("Code snippet")).not.toBeInTheDocument();
+		expect(screen.getByText("Foo")).toBeInTheDocument();
+	});
+
+	it("should not be rendered within a disclosure element if the text content doesn't have a `section`", () => {
+		render(
+			<PrismFormatted
+				getCodeBlockAriaLabel={getCodeBlockAriaLabel}
+				text="<pre><code class='language-js'>Foo</code></pre>"
+				isCollapsible
+				disclosureLabel="Code snippet"
+			/>,
+		);
+
+		expect(screen.queryByRole("group")).not.toBeInTheDocument();
+		expect(screen.queryByText("Code snippet")).not.toBeInTheDocument();
+		expect(screen.getByText("Foo")).toBeInTheDocument();
+	});
 });
+
+// ------------------------------
+// Type tests
+// ------------------------------
+// @ts-expect-error - `disclosureLabel` cannot be set if `isCollapsible` is undefined
+<PrismFormatted
+	getCodeBlockAriaLabel={getCodeBlockAriaLabel}
+	text={text}
+	disclosureLabel="Example"
+/>;
+
+// @ts-expect-error - `disclosureLabel` cannot be set if `isCollapsible` is false
+<PrismFormatted
+	getCodeBlockAriaLabel={getCodeBlockAriaLabel}
+	text={text}
+	disclosureLabel="Example"
+	isCollapsible={false}
+/>;
+
+// @ts-expect-error - `disclosureLabel` is required if `isCollapsible` is true
+<PrismFormatted
+	getCodeBlockAriaLabel={getCodeBlockAriaLabel}
+	text={text}
+	isCollapsible
+/>;

--- a/src/prism-formatted/types.ts
+++ b/src/prism-formatted/types.ts
@@ -1,0 +1,21 @@
+interface PrismFormattedBaseProps {
+	className?: string;
+	text: string;
+	getCodeBlockAriaLabel: (codeName: string) => string;
+	useSpan?: boolean;
+	noAria?: boolean;
+	hasLineNumbers?: boolean;
+}
+
+type PrismFormattedDisclosure =
+	| {
+			isCollapsible?: false;
+			disclosureLabel?: never;
+	  }
+	| {
+			isCollapsible: true;
+			disclosureLabel: string;
+	  };
+
+export type PrismFormattedProps = PrismFormattedBaseProps &
+	PrismFormattedDisclosure;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR ports the collapsible behavior from /learn (I missed this feature when I implemented the component).

## Screenshot

<img width="1028" alt="Screenshot 2024-10-08 at 15 34 02" src="https://github.com/user-attachments/assets/3243fc0d-111a-4e35-821d-17ee0045c89d">

<!-- Feel free to add any additional description of changes below this line -->
