### PR TITLE
refactor: initialize questions directly

### DIFF
--- a/src/quiz/use-quiz.test.ts
+++ b/src/quiz/use-quiz.test.ts
@@ -125,17 +125,8 @@ describe("useQuiz", () => {
 			}),
 		);
 
-		act(() => {
-			// @ts-expect-error - onChange is an optional prop so it can be undefined.
-			// However, the function is included in the result of the hook.
-			result.current.questions[0].onChange(2);
-		});
-
-		act(() => {
-			// @ts-expect-error - onChange is an optional prop so it can be undefined.
-			// However, the function is included in the result of the hook.
-			result.current.questions[1].onChange(2);
-		});
+		act(() => result.current.questions[0].onChange(2));
+		act(() => result.current.questions[1].onChange(2));
 
 		expect(result.current.questions[0].selectedAnswer).toBe(2);
 		expect(result.current.questions[1].selectedAnswer).toBe(2);

--- a/src/quiz/use-quiz.ts
+++ b/src/quiz/use-quiz.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { type Question } from "./types";
 
@@ -18,34 +18,22 @@ export const useQuiz = ({
 	onSuccess,
 	onFailure,
 }: Props) => {
-	const [quizAnswers, setQuizAnswers] = useState<(number | undefined)[]>(
-		initialQuestions.map((question) => question.selectedAnswer),
-	);
-	const [questions, setQuestions] = useState<Question[]>([]);
+	const [questions, setQuestions] = useState<Question[]>(initialQuestions);
 	const [correctAnswerCount, setCorrectAnswerCount] = useState(0);
 
-	// Initialize the `questions` state and make it synchronized with `quizAnswers`.
-	// The synchronization is needed in order to reflect the correct `selectedAnswer`.
-	useEffect(() => {
-		const questionsWithChangeHandling = initialQuestions.map(
-			(question, index) => ({
-				...question,
-				onChange: (selectedAnswer: number) => {
-					setQuizAnswers((prevAnswers) =>
-						prevAnswers.map((prevAnswer, prevIndex) =>
-							prevIndex === index ? selectedAnswer : prevAnswer,
-						),
-					);
-				},
-				selectedAnswer: quizAnswers[index],
-			}),
-		);
-
-		setQuestions(questionsWithChangeHandling);
-		// We only need `quizAnswers` in the dependency array.
-		// Adding `initialQuestions` in will cause an infinite loop.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [quizAnswers]);
+	const questionsWithChangeHandling = questions.map((question, index) => ({
+		...question,
+		onChange: (selectedAnswer: number) => {
+			// update the selected answer for this question
+			setQuestions((prevQuestions) =>
+				prevQuestions.map((prevQuestion, prevIndex) =>
+					prevIndex === index
+						? { ...prevQuestion, selectedAnswer }
+						: prevQuestion,
+				),
+			);
+		},
+	}));
 
 	const validateAnswers = () => {
 		setQuestions((prevQuestion) => {
@@ -79,5 +67,9 @@ export const useQuiz = ({
 		});
 	};
 
-	return { questions, validateAnswers, correctAnswerCount };
+	return {
+		questions: questionsWithChangeHandling,
+		validateAnswers,
+		correctAnswerCount,
+	};
 };


### PR DESCRIPTION
Previously we prevented render loops by omitting a dependency, but it is simpler to use the initial set state (since that's stable between renders).

quizAnswers existed solely to update question.selectedAnswer, so I
took out the intermediary and updated questions directly.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
