### PR TITLE
feat: allow quiz answer value to have string type

### DIFF
--- a/src/quiz-question/answer.tsx
+++ b/src/quiz-question/answer.tsx
@@ -5,7 +5,8 @@ import { faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
 
 import { QuizQuestionValidation, type QuizQuestionAnswer } from "./types";
 
-interface AnswerProps extends QuizQuestionAnswer {
+interface AnswerProps<AnswerT extends number | string>
+	extends QuizQuestionAnswer<AnswerT> {
 	checked?: boolean;
 	disabled?: boolean;
 	validation?: QuizQuestionValidation;
@@ -101,13 +102,13 @@ const ValidationMessage = ({ state, message }: QuizQuestionValidation) => {
 	);
 };
 
-export const Answer = ({
+export const Answer = <AnswerT extends number | string>({
 	value,
 	label,
 	disabled,
 	checked,
 	validation,
-}: AnswerProps) => {
+}: AnswerProps<AnswerT>) => {
 	const getRadioWrapperCls = () => {
 		const cls = [...radioWrapperDefaultClasses];
 

--- a/src/quiz-question/quiz-question.stories.tsx
+++ b/src/quiz-question/quiz-question.stories.tsx
@@ -13,16 +13,16 @@ const story = {
 
 type Story = StoryObj<typeof QuizQuestion>;
 
-const QuizQuestionComp = ({
+const QuizQuestionComp = <AnswerT extends number | string>({
 	question,
 	answers = [],
 	disabled,
 	validation,
 	position,
 	selectedAnswer,
-}: Partial<QuizQuestionProps>) => {
+}: Partial<QuizQuestionProps<AnswerT>>) => {
 	const [answer, setAnswer] =
-		useState<QuizQuestionProps["selectedAnswer"]>(selectedAnswer);
+		useState<QuizQuestionProps<AnswerT>["selectedAnswer"]>(selectedAnswer);
 
 	return (
 		<QuizQuestion

--- a/src/quiz-question/quiz-question.test.tsx
+++ b/src/quiz-question/quiz-question.test.tsx
@@ -170,3 +170,64 @@ describe("<QuizQuestion />", () => {
 		).toBeInTheDocument();
 	});
 });
+
+// ------------------------------
+// Type tests
+// ------------------------------
+// QuizQuestion without explicit type
+<QuizQuestion
+	question="Lorem ipsum"
+	answers={[
+		{ label: "Option 1", value: "1" },
+		// @ts-expect-error - values must have the same type
+		{ label: "Option 2", value: 2 },
+		// @ts-expect-error - values must have the same type
+		{ label: "Option 3", value: 3 },
+	]}
+/>;
+
+// QuizQuestion with `number` type
+<QuizQuestion<number>
+	question="Lorem ipsum"
+	answers={[
+		// @ts-expect-error - `value` type must be in accordance with the specified type
+		{ label: "Option 1", value: "1" },
+		{ label: "Option 2", value: 2 },
+		{ label: "Option 3", value: 3 },
+	]}
+/>;
+
+// QuizQuestion with `string` type
+<QuizQuestion<string>
+	question="Lorem ipsum"
+	answers={[
+		// @ts-expect-error - `value` type must be in accordance with the specified type
+		{ label: "Option 1", value: 1 },
+		{ label: "Option 2", value: "2" },
+		{ label: "Option 3", value: "3" },
+	]}
+/>;
+
+// QuizQuestion with `value` as number and `selectedAnswer` as string
+<QuizQuestion<number>
+	question="Lorem ipsum"
+	answers={[
+		{ label: "Option 1", value: 1 },
+		{ label: "Option 2", value: 2 },
+		{ label: "Option 3", value: 3 },
+	]}
+	// @ts-expect-error - `value` and `selectedAnswer` must have the same type
+	selectedAnswer="1"
+/>;
+
+// QuizQuestion with `value` as string and `selectedAnswer` as number
+<QuizQuestion<string>
+	question="Lorem ipsum"
+	answers={[
+		{ label: "Option 1", value: "1" },
+		{ label: "Option 2", value: "2" },
+		{ label: "Option 3", value: "3" },
+	]}
+	// @ts-expect-error - `value` and `selectedAnswer` must have the same type
+	selectedAnswer={1}
+/>;

--- a/src/quiz-question/quiz-question.tsx
+++ b/src/quiz-question/quiz-question.tsx
@@ -32,7 +32,7 @@ const QuestionText = ({
  * but instead, it provides a `selectedAnswer` and an `onChange` props,
  * giving the parent component full control over the selection handling logic.
  */
-export const QuizQuestion = ({
+export const QuizQuestion = <AnswerT extends number | string>({
 	question,
 	answers,
 	required,
@@ -41,8 +41,10 @@ export const QuizQuestion = ({
 	selectedAnswer,
 	onChange,
 	position,
-}: QuizQuestionProps) => {
-	const handleChange = (selectedOption: QuizQuestionAnswer["value"]) => {
+}: QuizQuestionProps<AnswerT>) => {
+	const handleChange = (
+		selectedOption: QuizQuestionAnswer<AnswerT>["value"],
+	) => {
 		if (!onChange) {
 			return;
 		}

--- a/src/quiz-question/types.ts
+++ b/src/quiz-question/types.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from "react";
 
-export interface QuizQuestionAnswer {
+export interface QuizQuestionAnswer<T extends number | string> {
 	label: ReactNode;
-	value: number | string;
+	value: T;
 }
 
 export interface QuizQuestionValidation {
@@ -10,7 +10,7 @@ export interface QuizQuestionValidation {
 	message: string;
 }
 
-export interface QuizQuestionProps {
+export interface QuizQuestionProps<AnswerT extends number | string> {
 	/**
 	 * Question text, can be plain text or contain code.
 	 * If the question text contains code, use the PrismFormatted component to ensure the code is rendered correctly.
@@ -20,7 +20,7 @@ export interface QuizQuestionProps {
 	/**
 	 * Answer options
 	 */
-	answers: QuizQuestionAnswer[];
+	answers: QuizQuestionAnswer<AnswerT>[];
 
 	/**
 	 * Position of the question amongst its siblings
@@ -45,10 +45,10 @@ export interface QuizQuestionProps {
 	/**
 	 * Value of the selected answer
 	 */
-	selectedAnswer?: QuizQuestionAnswer["value"];
+	selectedAnswer?: QuizQuestionAnswer<AnswerT>["value"];
 
 	/**
 	 * Change event handler, called when an answer is selected
 	 */
-	onChange?: (selectedAnswer: QuizQuestionAnswer["value"]) => void;
+	onChange?: (selectedAnswer: QuizQuestionAnswer<AnswerT>["value"]) => void;
 }

--- a/src/quiz-question/types.ts
+++ b/src/quiz-question/types.ts
@@ -45,10 +45,10 @@ export interface QuizQuestionProps<AnswerT extends number | string> {
 	/**
 	 * Value of the selected answer
 	 */
-	selectedAnswer?: QuizQuestionAnswer<AnswerT>["value"];
+	selectedAnswer?: AnswerT;
 
 	/**
 	 * Change event handler, called when an answer is selected
 	 */
-	onChange?: (selectedAnswer: QuizQuestionAnswer<AnswerT>["value"]) => void;
+	onChange?: (selectedAnswer: AnswerT) => void;
 }

--- a/src/quiz-question/types.ts
+++ b/src/quiz-question/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 export interface QuizQuestionAnswer {
 	label: ReactNode;
-	value: number;
+	value: number | string;
 }
 
 export interface QuizQuestionValidation {

--- a/src/quiz/quiz.stories.tsx
+++ b/src/quiz/quiz.stories.tsx
@@ -15,7 +15,7 @@ const story = {
 type Story = StoryObj<typeof Quiz>;
 
 const QuizDefault = () => {
-	const initialQuestions: Question[] = [
+	const initialQuestions: Question<number>[] = [
 		{
 			question: "Lorem ipsum dolor sit amet",
 			answers: [
@@ -57,7 +57,7 @@ const QuizDefault = () => {
 };
 
 const QuizWithValidation = () => {
-	const initialQuestions: Question[] = [
+	const initialQuestions: Question<number>[] = [
 		{
 			question: "Lorem ipsum dolor sit amet",
 			answers: [

--- a/src/quiz/quiz.test.tsx
+++ b/src/quiz/quiz.test.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { Quiz, QuizProps } from "./quiz";
+import { Quiz } from "./quiz";
+import { type QuizProps } from "./types";
 import { useQuiz } from "./use-quiz";
 
-const ControlledQuiz = ({ disabled, required }: Partial<QuizProps>) => {
+const ControlledQuiz = ({ disabled, required }: Partial<QuizProps<number>>) => {
 	const { questions } = useQuiz({
 		initialQuestions: [
 			{
@@ -122,3 +123,117 @@ describe("<Quiz />", () => {
 		});
 	});
 });
+
+// ------------------------------
+// Type tests
+// ------------------------------
+// Quiz without explicit type
+<Quiz
+	questions={[
+		{
+			question: "Lorem ipsum dolor sit amet",
+			answers: [
+				{ label: "Option 1", value: "1" },
+				// @ts-expect-error - values must have the same type
+				{ label: "Option 2", value: 2 },
+				// @ts-expect-error - values must have the same type
+				{ label: "Option 3", value: 3 },
+			],
+		},
+	]}
+/>;
+
+// Quiz with `number` type
+<Quiz<number>
+	questions={[
+		{
+			question: "Lorem ipsum dolor sit amet",
+			answers: [
+				// @ts-expect-error - `value` type must be in accordance with the specified type
+				{ label: "Option 1", value: "1" },
+				{ label: "Option 2", value: 2 },
+				{ label: "Option 3", value: 3 },
+			],
+			correctAnswer: 1,
+		},
+	]}
+/>;
+
+// Quiz with `string` type
+<Quiz<string>
+	questions={[
+		{
+			question: "Lorem ipsum dolor sit amet",
+			answers: [
+				// @ts-expect-error - `value` type must be in accordance with the specified type
+				{ label: "Option 1", value: 1 },
+				{ label: "Option 2", value: "2" },
+				{ label: "Option 3", value: "3" },
+			],
+		},
+	]}
+/>;
+
+// Quiz with `value` as number and `selectedAnswer` as string
+<Quiz<number>
+	questions={[
+		{
+			question: "Lorem ipsum dolor sit amet",
+			answers: [
+				{ label: "Option 1", value: 1 },
+				{ label: "Option 2", value: 2 },
+				{ label: "Option 3", value: 3 },
+			],
+			// @ts-expect-error - `value` and `selectedAnswer` must have the same type
+			selectedAnswer: "1",
+		},
+	]}
+/>;
+
+// Quiz with `value` as string and `selectedAnswer` as number
+<Quiz<string>
+	questions={[
+		{
+			question: "Lorem ipsum dolor sit amet",
+			answers: [
+				{ label: "Option 1", value: "1" },
+				{ label: "Option 2", value: "2" },
+				{ label: "Option 3", value: "3" },
+			],
+			// @ts-expect-error - `value` and `selectedAnswer` must have the same type
+			selectedAnswer: 1,
+		},
+	]}
+/>;
+
+// Quiz with `value` as number and `correctAnswer` as string
+<Quiz<number>
+	questions={[
+		{
+			question: "Lorem ipsum dolor sit amet",
+			answers: [
+				{ label: "Option 1", value: 1 },
+				{ label: "Option 2", value: 2 },
+				{ label: "Option 3", value: 3 },
+			],
+			// @ts-expect-error - `value` and `selectedAnswer` must have the same type
+			correctAnswer: "1",
+		},
+	]}
+/>;
+
+// Quiz with `value` as string and `correctAnswer` as number
+<Quiz<string>
+	questions={[
+		{
+			question: "Lorem ipsum dolor sit amet",
+			answers: [
+				{ label: "Option 1", value: "1" },
+				{ label: "Option 2", value: "2" },
+				{ label: "Option 3", value: "3" },
+			],
+			// @ts-expect-error - `value` and `selectedAnswer` must have the same type
+			correctAnswer: 1,
+		},
+	]}
+/>;

--- a/src/quiz/quiz.tsx
+++ b/src/quiz/quiz.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 
 import { QuizQuestion } from "../quiz-question";
-import { type Question } from "./types";
+import { type QuizProps } from "./types";
 
-export interface QuizProps {
-	questions: Question[];
-	disabled?: boolean;
-	required?: boolean;
-}
-
-export const Quiz = ({ questions, disabled, required }: QuizProps) => {
+export const Quiz = <AnswerT extends number | string>({
+	questions,
+	disabled,
+	required,
+}: QuizProps<AnswerT>) => {
 	return (
 		<ul className="flex flex-col gap-y-[24px]">
 			{questions.map((question, index) => (

--- a/src/quiz/types.ts
+++ b/src/quiz/types.ts
@@ -4,32 +4,38 @@ import type {
 	QuizQuestionProps,
 } from "../quiz-question";
 
+export interface QuizProps<AnswerT extends number | string> {
+	questions: Question<AnswerT>[];
+	disabled?: boolean;
+	required?: boolean;
+}
+
 // This interface is a subset of QuizQuestionProps.
 // The props are limited to ensure that
 // their configurations don't collide with Quiz'.
 // For example: Quiz should be able to apply `disabled` to all questions
 // without being overriden by the `disabled` prop of the individual question.
-export interface Question {
+export interface Question<AnswerT extends number | string> {
 	/**
 	 * Question text, can be plain text or contain code.
 	 * If the question text contains code, use the PrismFormatted component to ensure the code is rendered correctly.
 	 */
-	question: QuizQuestionProps["question"];
+	question: QuizQuestionProps<AnswerT>["question"];
 
 	/**
 	 * Answer options
 	 */
-	answers: QuizQuestionAnswer[];
+	answers: QuizQuestionAnswer<AnswerT>[];
 
 	/**
 	 * Value of the correct answer
 	 */
-	correctAnswer: QuizQuestionAnswer["value"];
+	correctAnswer: QuizQuestionAnswer<AnswerT>["value"];
 
 	/**
 	 * Change event handler, called when an answer is selected
 	 */
-	onChange?: (selectedOption: number) => void;
+	onChange?: (selectedAnswer: QuizQuestionAnswer<AnswerT>["value"]) => void;
 
 	/**
 	 * Information needed to render the validation status
@@ -39,5 +45,5 @@ export interface Question {
 	/**
 	 * Value of the selected answer
 	 */
-	selectedAnswer?: QuizQuestionAnswer["value"];
+	selectedAnswer?: QuizQuestionAnswer<AnswerT>["value"];
 }

--- a/src/quiz/types.ts
+++ b/src/quiz/types.ts
@@ -30,12 +30,12 @@ export interface Question<AnswerT extends number | string> {
 	/**
 	 * Value of the correct answer
 	 */
-	correctAnswer: QuizQuestionAnswer<AnswerT>["value"];
+	correctAnswer: AnswerT;
 
 	/**
 	 * Change event handler, called when an answer is selected
 	 */
-	onChange?: (selectedAnswer: QuizQuestionAnswer<AnswerT>["value"]) => void;
+	onChange?: (selectedAnswer: AnswerT) => void;
 
 	/**
 	 * Information needed to render the validation status
@@ -45,5 +45,5 @@ export interface Question<AnswerT extends number | string> {
 	/**
 	 * Value of the selected answer
 	 */
-	selectedAnswer?: QuizQuestionAnswer<AnswerT>["value"];
+	selectedAnswer?: AnswerT;
 }

--- a/src/quiz/types.ts
+++ b/src/quiz/types.ts
@@ -39,5 +39,5 @@ export interface Question {
 	/**
 	 * Value of the selected answer
 	 */
-	selectedAnswer?: number;
+	selectedAnswer?: QuizQuestionAnswer["value"];
 }

--- a/src/quiz/use-quiz.ts
+++ b/src/quiz/use-quiz.ts
@@ -18,7 +18,7 @@ export const useQuiz = ({
 	onSuccess,
 	onFailure,
 }: Props) => {
-	const [quizAnswers, setQuizAnswers] = useState<(number | undefined)[]>(
+	const [quizAnswers, setQuizAnswers] = useState<Question["selectedAnswer"][]>(
 		initialQuestions.map((question) => question.selectedAnswer),
 	);
 	const [questions, setQuestions] = useState<Question[]>([]);

--- a/src/quiz/use-quiz.ts
+++ b/src/quiz/use-quiz.ts
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 
 import { type Question } from "./types";
 
-interface Props {
-	initialQuestions: Question[];
+interface Props<AnswerT extends number | string> {
+	initialQuestions: Question<AnswerT>[];
 	validationMessages: {
 		correct: string;
 		incorrect: string;
@@ -12,16 +12,16 @@ interface Props {
 	onFailure?: () => void;
 }
 
-export const useQuiz = ({
+export const useQuiz = <AnswerT extends number | string>({
 	initialQuestions,
 	validationMessages,
 	onSuccess,
 	onFailure,
-}: Props) => {
-	const [quizAnswers, setQuizAnswers] = useState<Question["selectedAnswer"][]>(
-		initialQuestions.map((question) => question.selectedAnswer),
-	);
-	const [questions, setQuestions] = useState<Question[]>([]);
+}: Props<AnswerT>) => {
+	const [quizAnswers, setQuizAnswers] = useState<
+		Question<AnswerT>["selectedAnswer"][]
+	>(initialQuestions.map((question) => question.selectedAnswer));
+	const [questions, setQuestions] = useState<Question<AnswerT>[]>([]);
 	const [correctAnswerCount, setCorrectAnswerCount] = useState(0);
 
 	// Initialize the `questions` state and make it synchronized with `quizAnswers`.
@@ -30,7 +30,7 @@ export const useQuiz = ({
 		const questionsWithChangeHandling = initialQuestions.map(
 			(question, index) => ({
 				...question,
-				onChange: (selectedAnswer: number) => {
+				onChange: (selectedAnswer: AnswerT) => {
 					setQuizAnswers((prevAnswers) =>
 						prevAnswers.map((prevAnswer, prevIndex) =>
 							prevIndex === index ? selectedAnswer : prevAnswer,
@@ -49,19 +49,21 @@ export const useQuiz = ({
 
 	const validateAnswers = () => {
 		setQuestions((prevQuestion) => {
-			const updatedQuestions: Question[] = prevQuestion.map((question) => {
-				const validation: Question["validation"] =
-					question.selectedAnswer === question.correctAnswer
-						? {
-								state: "correct",
-								message: validationMessages.correct,
-							}
-						: {
-								state: "incorrect",
-								message: validationMessages.incorrect,
-							};
-				return { ...question, validation };
-			});
+			const updatedQuestions: Question<AnswerT>[] = prevQuestion.map(
+				(question) => {
+					const validation: Question<AnswerT>["validation"] =
+						question.selectedAnswer === question.correctAnswer
+							? {
+									state: "correct",
+									message: validationMessages.correct,
+								}
+							: {
+									state: "incorrect",
+									message: validationMessages.incorrect,
+								};
+					return { ...question, validation };
+				},
+			);
 
 			const correctCount = updatedQuestions.filter(
 				({ validation }) => validation?.state === "correct",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The value of `QuizQuestion` answer is currently a number. This matches the challenge schema in /learn, but not in the exam environment, where the answer values are strings (the app uses answer IDs for values, and answer IDs are strings).

This PR updates QuizQuestion and Quiz answer to accommodate for string values.

<!-- Feel free to add any additional description of changes below this line -->
