### PR TITLE
fix: remove default text color in `p`

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -40,7 +40,6 @@
 	h6,
 	p {
 		margin-bottom: 12.5px;
-		color: var(--foreground-primary);
 	}
 
 	/* Override the Tailwind's placeholder text color. */


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I recently added a default text color for headings and `p`. The intention was to reduce the need to set text color in each component. However, this change breaks components that display different text color (here is one: https://opensource.freecodecamp.org/ui/?path=/story/components-alert--with-heading-and-paragraphs). 

I'm reverting the change, as I think it's safer to just be explicit in what color we want the component / element to have. Having a default color might also put the consumers in the situation where they have to do some weird CSS trick to override.

<details>
<summary>Screenshot</summary>

| Before | After |
| --- | --- |
| <img width="1370" alt="Screenshot 2024-10-11 at 16 16 23" src="https://github.com/user-attachments/assets/508a4cc1-5f8b-450b-bb84-9f1b2958ce5c"> | <img width="1243" alt="Screenshot 2024-10-11 at 16 03 14" src="https://github.com/user-attachments/assets/86d0b7f9-d671-4b67-bc71-5ec163f6348b"> |

</details>

<!-- Feel free to add any additional description of changes below this line -->
