### PR TITLE
fix: display quiz correct count on demo

### DIFF
--- a/src/quiz/quiz.stories.tsx
+++ b/src/quiz/quiz.stories.tsx
@@ -103,7 +103,11 @@ const QuizWithValidation = () => {
 
 	return (
 		<div>
-			{correctAnswerCount && <p>Correct answers: {correctAnswerCount}</p>}
+			{correctAnswerCount > -1 && (
+				<div aria-live="polite">
+					<p>Correct answers: {correctAnswerCount}</p>
+				</div>
+			)}
 			<Quiz questions={questions} disabled={disabled} />
 			<Spacer size="m" />
 			<Button onClick={handleSubmit}>Submit</Button>

--- a/src/quiz/use-quiz.ts
+++ b/src/quiz/use-quiz.ts
@@ -20,7 +20,7 @@ export const useQuiz = <AnswerT extends number | string>({
 }: Props<AnswerT>) => {
 	const [questions, setQuestions] =
 		useState<Question<AnswerT>[]>(initialQuestions);
-	const [correctAnswerCount, setCorrectAnswerCount] = useState(0);
+	const [correctAnswerCount, setCorrectAnswerCount] = useState(-1);
 
 	const questionsWithChangeHandling = questions.map((question, index) => ({
 		...question,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #366

<!-- Feel free to add any additional description of changes below this line -->
I chose to set the initial state of the correct answer count to -1 so I can keep the Typescript intellisense satisfied. It doesn't like if I make the `correctAnswerCount` null so I didn't. Thankfully when the user hits submit, the `correctAnswerCount` is set to the number of correct answers later on.  

If there's a more elegant less error prone solution, I'd like to hear it. Cause if the question validation checker changes the implementation to simply add the correct count, things could get ugly. 