### PR TITLE
feat: add data-value attribute to QuizQuestion answer

### DIFF
--- a/src/quiz-question/answer.tsx
+++ b/src/quiz-question/answer.tsx
@@ -134,6 +134,7 @@ export const Answer = <AnswerT extends number | string>({
 			<RadioGroup.Option
 				key={value}
 				value={value}
+				data-value={value}
 				className={getRadioOptionCls()}
 			>
 				{({ active }) => (

--- a/src/quiz-question/quiz-question.test.tsx
+++ b/src/quiz-question/quiz-question.test.tsx
@@ -24,6 +24,19 @@ describe("<QuizQuestion />", () => {
 		expect(screen.getByRole("radio", { name: "Option 1" })).toBeInTheDocument();
 		expect(screen.getByRole("radio", { name: "Option 2" })).toBeInTheDocument();
 		expect(screen.getByRole("radio", { name: "Option 3" })).toBeInTheDocument();
+
+		expect(screen.getByRole("radio", { name: "Option 1" })).toHaveAttribute(
+			"data-value",
+			"1",
+		);
+		expect(screen.getByRole("radio", { name: "Option 2" })).toHaveAttribute(
+			"data-value",
+			"2",
+		);
+		expect(screen.getByRole("radio", { name: "Option 3" })).toHaveAttribute(
+			"data-value",
+			"3",
+		);
 	});
 
 	it("should have the `required` attribute set to `true` if the `required` prop is specified", () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was writing some e2e tests for the quiz challenge in /learn, and I found that I could not access the `value` of each answer.

```ts
getByRole('radio').getAttribute('value') // returns null
```

Usually with `input` elements, there would be a `value` attribute. But the radio component we use (from Headless UI) is built with `<div role="radio">`, and I'm not sure where it stores `value`.

This PR adds a `data-value` attribute to the radio component, so that we can use it to target the option in tests.

<!-- Feel free to add any additional description of changes below this line -->
