### PR TITLE
fix(Quiz): remove marker from list items

### DIFF
--- a/src/quiz/quiz.tsx
+++ b/src/quiz/quiz.tsx
@@ -9,7 +9,7 @@ export const Quiz = <AnswerT extends number | string>({
 	required,
 }: QuizProps<AnswerT>) => {
 	return (
-		<ul className="flex flex-col gap-y-[48px]">
+		<ul className="flex flex-col gap-y-[48px] list-none">
 			{questions.map((question, index) => (
 				<li key={index}>
 					<QuizQuestion


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We now have `list-style-type: disc` in the default `ul` styles:

https://github.com/freeCodeCamp/ui/blob/e948ebbeabc8913b470e164d932ad6d19eecd864/src/base.css#L92

So this rule needs to be overridden in Quiz, otherwise there is a bullet point next to each quiz question.

| Before | After |
| --- | --- |
| <img width="954" alt="Screenshot 2025-03-24 at 13 57 14" src="https://github.com/user-attachments/assets/3d2291b4-2c5f-419e-8d37-cf28df18435b" /> | <img width="949" alt="Screenshot 2025-03-24 at 13 58 36" src="https://github.com/user-attachments/assets/54391d04-a49b-4216-80cb-da10f3fe5a49" /> |

<!-- Feel free to add any additional description of changes below this line -->
