### PR TITLE
fix(FormControl): handle props spreading properly

### DIFF
--- a/src/form-control/form-control-feedback.tsx
+++ b/src/form-control/form-control-feedback.tsx
@@ -3,14 +3,14 @@ import React, { type ComponentProps } from "react";
 export const FormControlFeedback = ({
 	children,
 	className,
-	...props
+	...otherProps
 }: ComponentProps<"span">): JSX.Element => {
 	const defaultClasses =
 		"absolute top-[30px] right-0 z-2 block w-8 h-8 leading-8 text-center pointer-events-none text-green-700";
 
-	const classes = [className, defaultClasses].join(" ");
+	const classes = [defaultClasses, className].join(" ");
 	return (
-		<span className={classes} {...props}>
+		<span className={classes} {...otherProps}>
 			{children}
 		</span>
 	);

--- a/src/form-control/form-control-static.tsx
+++ b/src/form-control/form-control-static.tsx
@@ -3,13 +3,13 @@ import React, { type ComponentProps } from "react";
 export const FormControlStatic = ({
 	className,
 	children,
-	...props
+	...otherProps
 }: ComponentProps<"p">): JSX.Element => {
 	const defaultClasses = "py-1.5 mb-0 min-h-43-px text-foreground-secondary";
 
 	const classes = [defaultClasses, className].join(" ");
 	return (
-		<p className={classes} {...props}>
+		<p className={classes} {...otherProps}>
 			{children}
 		</p>
 	);

--- a/src/form-control/form-control.tsx
+++ b/src/form-control/form-control.tsx
@@ -13,18 +13,35 @@ const defaultClasses =
 
 const FormControl = ({
 	componentClass,
-	...props
+	id,
+	className,
+	...otherProps
 }: FormControlProps<"input" | "textarea">): JSX.Element => {
 	const { controlId } = useContext(FormContext);
-	const { id, className } = props;
 
 	const Component = componentClass || "input";
 	if (Component !== "textarea") variantClass = " h-8";
 
 	//row and componentClass
-	const classes = [className, defaultClasses, variantClass].join(" ");
+	const classes = [defaultClasses, variantClass, className].join(" ");
 
-	return <Component id={id || controlId} className={classes} {...props} />;
+	if (Component === "textarea") {
+		return (
+			<textarea
+				id={id || controlId}
+				className={classes}
+				{...(otherProps as React.TextareaHTMLAttributes<HTMLTextAreaElement>)}
+			/>
+		);
+	}
+
+	return (
+		<input
+			id={id || controlId}
+			className={classes}
+			{...(otherProps as React.InputHTMLAttributes<HTMLInputElement>)}
+		/>
+	);
 };
 
 FormControl.Feedback = FormControlFeedback;

--- a/src/form-control/types.ts
+++ b/src/form-control/types.ts
@@ -1,9 +1,7 @@
-import React, { type ComponentProps } from "react";
+import React from "react";
 
-export type FormControlProps<
-	TElement extends
-		| keyof JSX.IntrinsicElements
-		| React.JSXElementConstructor<unknown> = "input",
-> = {
-	componentClass?: TElement | string;
-} & ComponentProps<TElement>;
+export type FormControlProps<T extends "input" | "textarea" = "input"> = {
+	componentClass?: T;
+} & (T extends "textarea"
+	? React.TextareaHTMLAttributes<HTMLTextAreaElement>
+	: React.InputHTMLAttributes<HTMLInputElement>);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We're passing the combined class names (default + custom) to the component, but the default class names are overridden by the custom `className` because we're spreading the entire `props` object after that.

https://github.com/freeCodeCamp/ui/blob/db06a09336b5c9bf8d492e88a40c140b561e9a5f/src/form-control/form-control.tsx#L25-L27

<!-- Feel free to add any additional description of changes below this line -->
