### PR TITLE
fix: remove preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/freeCodeCamp/ui#readme",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "prepublishOnly": "pnpm run build",
     "build-storybook": "storybook build",
     "build": "pnpm clean && pnpm build:css && pnpm build:js",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Shaun pointed out that the package cannot be installed in a project using a package manager other than pnpm.

From what I understand, lifecycle scripts (like `preinstall`) declared in a package's own `package.json` are executed when that package is installed as a dependency. So enforcing `pnpm` would cause installs to fail for consumers using `npm` or `yarn`.

Related issue: https://github.com/pnpm/pnpm/issues/4278

Closes #689 
