### PR TITLE
fix(callout): explicitly style label for higher specificity

### DIFF
--- a/src/callout/callout.tsx
+++ b/src/callout/callout.tsx
@@ -15,6 +15,13 @@ const variantClasses = {
 	caution: "text-red-900 bg-red-50 border-l-red-700",
 };
 
+const variantLabelClasses = {
+	tip: "text-green-800",
+	note: "text-blue-800",
+	warning: "text-yellow-800",
+	caution: "text-red-900",
+};
+
 const variantIcons = {
 	tip: faCircleCheck,
 	note: faCircleInfo,
@@ -53,7 +60,7 @@ export const Callout = ({
 		<div className={classes} {...others}>
 			<div className="flex items-start mb-2">
 				<FontAwesomeIcon icon={variantIcons[variant]} className="me-2 mt-1" />
-				<strong>{label}</strong>
+				<strong className={variantLabelClasses[variant]}>{label}</strong>
 			</div>
 			{children}
 		</div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a bit annoying.

Within the library, the Callout's label has the correct text color, but when used in the /learn client, the color is being overridden by https://github.com/freeCodeCamp/freeCodeCamp/blob/2f9057158359338dbbe4829d39a9504edebb598a/client/src/components/layouts/global.css#L480-L482.

So I'm fighting the specificity by adding a class to the label.

<!-- Feel free to add any additional description of changes below this line -->
