### PR TITLE
feat: add label components for Quiz

### DIFF
--- a/src/quiz-question/quiz-question.stories.tsx
+++ b/src/quiz-question/quiz-question.stories.tsx
@@ -38,9 +38,11 @@ const QuizQuestionComp = <AnswerT extends number | string>({
 export const Default: Story = {
 	render: QuizQuestionComp,
 	args: {
-		question: "Lorem ipsum dolor sit amet, consectetur adipiscing elit?",
+		question: (
+			<QuizQuestion.QuestionLabel text="Lorem ipsum dolor sit amet, consectetur adipiscing elit?" />
+		),
 		answers: [
-			{ label: "Option 1", value: 1 },
+			{ label: <QuizQuestion.OptionLabel text="Option 1" />, value: 1 },
 			{
 				label:
 					"Tempora sed magnam consequatur dolor alias placeat aspernatur. Odio et non repudiandae debitis fugit. Quia ut tempore eaque et nisi qui aspernatur. Molestiae sed id accusantium. Temporibus in magni ut. Est aut distinctio molestiae sed. Dicta consequatur impedit totam totam incidunt dolor possimus. Aut totam officia iure consequatur ea.",
@@ -168,22 +170,21 @@ export const WithCodeInQuestionText: Story = {
 	render: QuizQuestionComp,
 	args: {
 		question: (
-			<PrismFormatted
+			<QuizQuestion.QuestionLabel
 				text={`<p>Given the following code:</p>
-<pre><code class="language-python">temp = "5 degrees"
-cel = 0
-fahr = float(temp)
-cel = (fahr - 32.0) * 5.0 / 9.0
-print(cel)
-</code></pre>
-<p>Which line/lines should be surrounded by <code>try</code> block?</p>`}
-				getCodeBlockAriaLabel={(codeName) => `${codeName} code example`}
+	<pre><code class="language-python">temp = "5 degrees"
+	cel = 0
+	fahr = float(temp)
+	cel = (fahr - 32.0) * 5.0 / 9.0
+	print(cel)
+	</code></pre>
+	<p>Which line/lines should be surrounded by <code>try</code> block?</p>`}
 			/>
 		),
 		answers: [
-			{ label: "Option 1", value: 1 },
-			{ label: "Option 2", value: 2 },
-			{ label: "Option 3", value: 3 },
+			{ label: <QuizQuestion.OptionLabel text="Option 1" />, value: 1 },
+			{ label: <QuizQuestion.OptionLabel text="Option 2" />, value: 2 },
+			{ label: <QuizQuestion.OptionLabel text="Option 3" />, value: 3 },
 		],
 	},
 	parameters: {
@@ -225,11 +226,13 @@ print(cel)
 export const Disabled: Story = {
 	render: QuizQuestionComp,
 	args: {
-		question: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+		question: (
+			<QuizQuestion.QuestionLabel text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
+		),
 		answers: [
-			{ label: "Option 1", value: 1 },
-			{ label: "Option 2", value: 2 },
-			{ label: "Option 3", value: 3 },
+			{ label: <QuizQuestion.OptionLabel text="Option 1" />, value: 1 },
+			{ label: <QuizQuestion.OptionLabel text="Option 2" />, value: 2 },
+			{ label: <QuizQuestion.OptionLabel text="Option 3" />, value: 3 },
 		],
 		disabled: true,
 	},
@@ -261,10 +264,12 @@ export const Disabled: Story = {
 export const Correct: Story = {
 	render: QuizQuestionComp,
 	args: {
-		question: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+		question: (
+			<QuizQuestion.QuestionLabel text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
+		),
 		answers: [
 			{
-				label: "Option 1",
+				label: <QuizQuestion.OptionLabel text="Option 1" />,
 				value: 1,
 				validation: {
 					state: "correct",
@@ -272,11 +277,11 @@ export const Correct: Story = {
 				},
 			},
 			{
-				label: "Option 2",
+				label: <QuizQuestion.OptionLabel text="Option 2" />,
 				value: 2,
 			},
 			{
-				label: "Option 3",
+				label: <QuizQuestion.OptionLabel text="Option 3" />,
 				value: 3,
 			},
 		],
@@ -319,10 +324,12 @@ export const Correct: Story = {
 export const CorrectWithAnswerFeedback: Story = {
 	render: QuizQuestionComp,
 	args: {
-		question: "Lorem ipsum dolor sit amet, consectetur adipiscing elit?",
+		question: (
+			<QuizQuestion.QuestionLabel text="Lorem ipsum dolor sit amet, consectetur adipiscing elit?" />
+		),
 		answers: [
 			{
-				label: "Option 1",
+				label: <QuizQuestion.OptionLabel text="Option 1" />,
 				value: 1,
 				feedback: (
 					<PrismFormatted
@@ -332,8 +339,8 @@ export const CorrectWithAnswerFeedback: Story = {
 				),
 				validation: { state: "correct", message: "Correct." },
 			},
-			{ label: "Option 2", value: 2 },
-			{ label: "Option 3", value: 3 },
+			{ label: <QuizQuestion.OptionLabel text="Option 2" />, value: 2 },
+			{ label: <QuizQuestion.OptionLabel text="Option 3" />, value: 3 },
 		],
 		selectedAnswer: 1,
 		disabled: true,
@@ -439,10 +446,12 @@ export const Incorrect: Story = {
 export const IncorrectWithAnswerFeedback: Story = {
 	render: QuizQuestionComp,
 	args: {
-		question: "Lorem ipsum dolor sit amet, consectetur adipiscing elit?",
+		question: (
+			<QuizQuestion.QuestionLabel text="Lorem ipsum dolor sit amet, consectetur adipiscing elit?" />
+		),
 		answers: [
 			{
-				label: "Option 1",
+				label: <QuizQuestion.OptionLabel text="Option 1" />,
 				value: 1,
 				feedback: (
 					<PrismFormatted
@@ -452,8 +461,8 @@ export const IncorrectWithAnswerFeedback: Story = {
 				),
 				validation: { state: "incorrect", message: "Incorrect." },
 			},
-			{ label: "Option 2", value: 2 },
-			{ label: "Option 3", value: 3 },
+			{ label: <QuizQuestion.OptionLabel text="Option 2" />, value: 2 },
+			{ label: <QuizQuestion.OptionLabel text="Option 3" />, value: 3 },
 		],
 		selectedAnswer: 1,
 		disabled: true,
@@ -497,7 +506,7 @@ export const WithPosistion: Story = {
 	render: QuizQuestionComp,
 	args: {
 		question: (
-			<PrismFormatted
+			<QuizQuestion.QuestionLabel
 				text={`<p>Given the following code:</p>
 <pre><code class="language-python">temp = "5 degrees"
 cel = 0
@@ -506,13 +515,12 @@ cel = (fahr - 32.0) * 5.0 / 9.0
 print(cel)
 </code></pre>
 <p>Which line/lines should be surrounded by <code>try</code> block?</p>`}
-				getCodeBlockAriaLabel={(codeName) => `${codeName} code example`}
 			/>
 		),
 		answers: [
-			{ label: "Option 1", value: 1 },
-			{ label: "Option 2", value: 2 },
-			{ label: "Option 3", value: 3 },
+			{ label: <QuizQuestion.OptionLabel text="Option 1" />, value: 1 },
+			{ label: <QuizQuestion.OptionLabel text="Option 2" />, value: 2 },
+			{ label: <QuizQuestion.OptionLabel text="Option 3" />, value: 3 },
 		],
 		position: 1,
 	},

--- a/src/quiz-question/quiz-question.tsx
+++ b/src/quiz-question/quiz-question.tsx
@@ -3,6 +3,40 @@ import { RadioGroup } from "@headlessui/react";
 
 import type { QuizQuestionAnswer, QuizQuestionProps } from "./types";
 import { Answer } from "./answer";
+import { PrismFormatted } from "../prism-formatted";
+
+type LabelProps = { text: string };
+
+const removeParagraphTags = (text: string): string => {
+	if (text.startsWith("<p>") && text.endsWith("</p>")) {
+		return text.slice(3, -4);
+	}
+	return text;
+};
+
+const defaultGetCodeBlockAriaLabel = (codeName: string) =>
+	`${codeName} code example`;
+
+const QuestionLabel = ({ text }: LabelProps) => {
+	return (
+		<PrismFormatted
+			text={text}
+			getCodeBlockAriaLabel={defaultGetCodeBlockAriaLabel}
+		/>
+	);
+};
+
+const OptionLabel = ({ text }: LabelProps) => {
+	const cleanedText = removeParagraphTags(text);
+	return (
+		<PrismFormatted
+			text={cleanedText}
+			useSpan
+			noAria
+			getCodeBlockAriaLabel={defaultGetCodeBlockAriaLabel}
+		/>
+	);
+};
 
 const QuestionText = ({
 	question,
@@ -24,6 +58,13 @@ const QuestionText = ({
 	);
 };
 
+type QuizQuestionComponent = (<AnswerT extends number | string>(
+	props: QuizQuestionProps<AnswerT>,
+) => JSX.Element) & {
+	QuestionLabel: typeof QuestionLabel;
+	OptionLabel: typeof OptionLabel;
+};
+
 /**
  * QuizQuestion is a radio group that allows users to select a single option from a list of multiple options.
  * The component can be used as a standalone component or in a group of multiple questions.
@@ -32,7 +73,7 @@ const QuestionText = ({
  * but instead, it provides a `selectedAnswer` and an `onChange` props,
  * giving the parent component full control over the selection handling logic.
  */
-export const QuizQuestion = <AnswerT extends number | string>({
+const QuizQuestionBase = <AnswerT extends number | string>({
 	question,
 	answers,
 	required,
@@ -82,3 +123,11 @@ export const QuizQuestion = <AnswerT extends number | string>({
 		</RadioGroup>
 	);
 };
+
+export const QuizQuestion: QuizQuestionComponent = Object.assign(
+	QuizQuestionBase,
+	{
+		QuestionLabel,
+		OptionLabel,
+	},
+);

--- a/src/quiz/quiz.stories.tsx
+++ b/src/quiz/quiz.stories.tsx
@@ -18,29 +18,31 @@ type Story = StoryObj<typeof Quiz>;
 const QuizDefault = () => {
 	const initialQuestions: Question<number>[] = [
 		{
-			question: "Lorem ipsum dolor sit amet",
+			question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
 			answers: [
-				{ label: "Option 1", value: 1 },
-				{ label: "Option 2", value: 2 },
-				{ label: "Option 3", value: 3 },
+				{ label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+				{ label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
 			],
 			correctAnswer: 1,
 		},
 		{
-			question: "Consectetur adipiscing elit",
+			question: <Quiz.QuestionLabel text="Consectetur adipiscing elit" />,
 			answers: [
-				{ label: "Option 1", value: 1 },
-				{ label: "Option 2", value: 2 },
-				{ label: "Option 3", value: 3 },
+				{ label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+				{ label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
 			],
 			correctAnswer: 2,
 		},
 		{
-			question: "Fugit itaque delectus voluptatem alias aliquid",
+			question: (
+				<Quiz.QuestionLabel text="Fugit itaque delectus voluptatem alias aliquid" />
+			),
 			answers: [
-				{ label: "Option 1", value: 1 },
-				{ label: "Option 2", value: 2 },
-				{ label: "Option 3", value: 3 },
+				{ label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+				{ label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
 			],
 			correctAnswer: 3,
 		},
@@ -61,29 +63,31 @@ const QuizDefault = () => {
 const QuizWithValidation = () => {
 	const initialQuestions: Question<number>[] = [
 		{
-			question: "Lorem ipsum dolor sit amet",
+			question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
 			answers: [
-				{ label: "Option 1", value: 1 },
-				{ label: "Option 2", value: 2 },
-				{ label: "Option 3", value: 3 },
+				{ label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+				{ label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
 			],
 			correctAnswer: 1,
 		},
 		{
-			question: "Consectetur adipiscing elit",
+			question: <Quiz.QuestionLabel text="Consectetur adipiscing elit" />,
 			answers: [
-				{ label: "Option 1", value: 1 },
-				{ label: "Option 2", value: 2 },
-				{ label: "Option 3", value: 3 },
+				{ label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+				{ label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
 			],
 			correctAnswer: 2,
 		},
 		{
-			question: "Fugit itaque delectus voluptatem alias aliquid",
+			question: (
+				<Quiz.QuestionLabel text="Fugit itaque delectus voluptatem alias aliquid" />
+			),
 			answers: [
-				{ label: "Option 1", value: 1 },
-				{ label: "Option 2", value: 2 },
-				{ label: "Option 3", value: 3 },
+				{ label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+				{ label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
 			],
 			correctAnswer: 3,
 		},
@@ -123,10 +127,10 @@ const QuizWithValidation = () => {
 const QuizWithValidationAndAnswerFeedback = () => {
 	const initialQuestions: Question<number>[] = [
 		{
-			question: "Lorem ipsum dolor sit amet",
+			question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
 			answers: [
 				{
-					label: "Option 1",
+					label: <Quiz.OptionLabel text="Option 1" />,
 					value: 1,
 					feedback: (
 						<PrismFormatted
@@ -136,20 +140,24 @@ const QuizWithValidationAndAnswerFeedback = () => {
 					),
 				},
 				{
-					label: "Option 2",
+					label: <Quiz.OptionLabel text="Option 2" />,
 					value: 2,
 					feedback:
 						"Recusandae necessitatibus consequatur voluptatem sapiente.",
 				},
-				{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
+				{
+					label: <Quiz.OptionLabel text="Option 3" />,
+					value: 3,
+					feedback: "Voluptas et et animi quo.",
+				},
 			],
 			correctAnswer: 1,
 		},
 		{
-			question: "Consectetur adipiscing elit",
+			question: <Quiz.QuestionLabel text="Consectetur adipiscing elit" />,
 			answers: [
 				{
-					label: "Option 1",
+					label: <Quiz.OptionLabel text="Option 1" />,
 					value: 1,
 					feedback: (
 						<PrismFormatted
@@ -159,20 +167,26 @@ const QuizWithValidationAndAnswerFeedback = () => {
 					),
 				},
 				{
-					label: "Option 2",
+					label: <Quiz.OptionLabel text="Option 2" />,
 					value: 2,
 					feedback:
 						"Recusandae necessitatibus consequatur voluptatem sapiente.",
 				},
-				{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
+				{
+					label: <Quiz.OptionLabel text="Option 3" />,
+					value: 3,
+					feedback: "Voluptas et et animi quo.",
+				},
 			],
 			correctAnswer: 2,
 		},
 		{
-			question: "Fugit itaque delectus voluptatem alias aliquid",
+			question: (
+				<Quiz.QuestionLabel text="Fugit itaque delectus voluptatem alias aliquid" />
+			),
 			answers: [
 				{
-					label: "Option 1",
+					label: <Quiz.OptionLabel text="Option 1" />,
 					value: 1,
 					feedback: (
 						<PrismFormatted
@@ -182,12 +196,16 @@ const QuizWithValidationAndAnswerFeedback = () => {
 					),
 				},
 				{
-					label: "Option 2",
+					label: <Quiz.OptionLabel text="Option 2" />,
 					value: 2,
 					feedback:
 						"Recusandae necessitatibus consequatur voluptatem sapiente.",
 				},
-				{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
+				{
+					label: <Quiz.OptionLabel text="Option 3" />,
+					value: 3,
+					feedback: "Voluptas et et animi quo.",
+				},
 			],
 			correctAnswer: 3,
 		},
@@ -227,10 +245,10 @@ const QuizWithValidationAndAnswerFeedback = () => {
 const QuizWithCorrectAnswersShownOnSuccess = () => {
 	const initialQuestions: Question<number>[] = [
 		{
-			question: "Lorem ipsum dolor sit amet",
+			question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
 			answers: [
 				{
-					label: "Option 1",
+					label: <Quiz.OptionLabel text="Option 1" />,
 					value: 1,
 					feedback: (
 						<PrismFormatted
@@ -240,20 +258,24 @@ const QuizWithCorrectAnswersShownOnSuccess = () => {
 					),
 				},
 				{
-					label: "Option 2",
+					label: <Quiz.OptionLabel text="Option 2" />,
 					value: 2,
 					feedback:
 						"Recusandae necessitatibus consequatur voluptatem sapiente.",
 				},
-				{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
+				{
+					label: <Quiz.OptionLabel text="Option 3" />,
+					value: 3,
+					feedback: "Voluptas et et animi quo.",
+				},
 			],
 			correctAnswer: 1,
 		},
 		{
-			question: "Consectetur adipiscing elit",
+			question: <Quiz.QuestionLabel text="Consectetur adipiscing elit" />,
 			answers: [
 				{
-					label: "Option 1",
+					label: <Quiz.OptionLabel text="Option 1" />,
 					value: 1,
 					feedback: (
 						<PrismFormatted
@@ -263,20 +285,26 @@ const QuizWithCorrectAnswersShownOnSuccess = () => {
 					),
 				},
 				{
-					label: "Option 2",
+					label: <Quiz.OptionLabel text="Option 2" />,
 					value: 2,
 					feedback:
 						"Recusandae necessitatibus consequatur voluptatem sapiente.",
 				},
-				{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
+				{
+					label: <Quiz.OptionLabel text="Option 3" />,
+					value: 3,
+					feedback: "Voluptas et et animi quo.",
+				},
 			],
 			correctAnswer: 2,
 		},
 		{
-			question: "Fugit itaque delectus voluptatem alias aliquid",
+			question: (
+				<Quiz.QuestionLabel text="Fugit itaque delectus voluptatem alias aliquid" />
+			),
 			answers: [
 				{
-					label: "Option 1",
+					label: <Quiz.OptionLabel text="Option 1" />,
 					value: 1,
 					feedback: (
 						<PrismFormatted
@@ -286,12 +314,16 @@ const QuizWithCorrectAnswersShownOnSuccess = () => {
 					),
 				},
 				{
-					label: "Option 2",
+					label: <Quiz.OptionLabel text="Option 2" />,
 					value: 2,
 					feedback:
 						"Recusandae necessitatibus consequatur voluptatem sapiente.",
 				},
-				{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
+				{
+					label: <Quiz.OptionLabel text="Option 3" />,
+					value: 3,
+					feedback: "Voluptas et et animi quo.",
+				},
 			],
 			correctAnswer: 3,
 		},
@@ -340,29 +372,29 @@ import { Quiz, useQuiz } from '@freecodecamp/ui';
 
 const initialQuestions = [
   {
-    question: "Lorem ipsum dolor sit amet",
+    question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
     answers: [
-      { label: "Option 1", value: 1 },
-      { label: "Option 2", value: 2 },
-      { label: "Option 3", value: 3 },
+      { label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+      { label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+      { label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
     ],
     correctAnswer: 1,
   },
   {
-    question: "Consectetur adipiscing elit",
+    question: <Quiz.QuestionLabel text="Consectetur adipiscing elit" />,
     answers: [
-      { label: "Option 1", value: 1 },
-      { label: "Option 2", value: 2 },
-      { label: "Option 3", value: 3 },
+      { label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+      { label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+      { label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
     ],
     correctAnswer: 2,
   },
   {
-    question: "Fugit itaque delectus voluptatem alias aliquid",
+    question: <Quiz.QuestionLabel text="Fugit itaque delectus voluptatem alias aliquid" />,
     answers: [
-      { label: "Option 1", value: 1 },
-      { label: "Option 2", value: 2 },
-      { label: "Option 3", value: 3 },
+      { label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+      { label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+      { label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
     ],
     correctAnswer: 3,
   },
@@ -395,29 +427,29 @@ import { Quiz, useQuiz, Button, Spacer } from '@freecodecamp/ui';
 
 const initialQuestions = [
   {
-    question: "Lorem ipsum dolor sit amet",
+    question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
     answers: [
-      { label: "Option 1", value: 1 },
-      { label: "Option 2", value: 2 },
-      { label: "Option 3", value: 3 },
+      { label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+      { label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+      { label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
     ],
     correctAnswer: 1,
   },
   {
-    question: "Consectetur adipiscing elit",
+    question: <Quiz.QuestionLabel text="Consectetur adipiscing elit" />,
     answers: [
-      { label: "Option 1", value: 1 },
-      { label: "Option 2", value: 2 },
-      { label: "Option 3", value: 3 },
+      { label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+      { label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+      { label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
     ],
     correctAnswer: 2,
   },
   {
-    question: "Fugit itaque delectus voluptatem alias aliquid",
+    question: <Quiz.QuestionLabel text="Fugit itaque delectus voluptatem alias aliquid" />,
     answers: [
-      { label: "Option 1", value: 1 },
-      { label: "Option 2", value: 2 },
-      { label: "Option 3", value: 3 },
+      { label: <Quiz.OptionLabel text="Option 1" />, value: 1 },
+      { label: <Quiz.OptionLabel text="Option 2" />, value: 2 },
+      { label: <Quiz.OptionLabel text="Option 3" />, value: 3 },
     ],
     correctAnswer: 3,
   },
@@ -469,12 +501,12 @@ export const WithValidationAndAnswerFeedback: Story = {
 import { Quiz, useQuiz, Button, Spacer } from '@freecodecamp/ui';
 
 const initialQuestions = [
-  {
-		question: "Lorem ipsum dolor sit amet",
-		answers: [
-			{
-				label: "Option 1",
-				value: 1,
+		{
+			question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
+			answers: [
+				{
+					label: <Quiz.OptionLabel text="Option 1" />,
+					value: 1,
 				feedback: (
 					<PrismFormatted
 						text={\`<p>Quaerat in autem sapiente illum. Vel mollitia omnis qui dolorem <code>um</code> esse eos maiores possimus. Est laborum quam aliquam qui sunt. Ut ea et qui provident voluptatibus. Eius quam odit sint cumque sint. Corporis quia et dicta.</p>\`}
@@ -482,22 +514,22 @@ const initialQuestions = [
 					/>
 				),
 			},
-			{
-				label: "Option 2",
-				value: 2,
+				{
+					label: <Quiz.OptionLabel text="Option 2" />,
+					value: 2,
 				feedback:
 					"Recusandae necessitatibus consequatur voluptatem sapiente.",
-			},
-			{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
-		],
+				},
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3, feedback: "Voluptas et et animi quo." },
+			],
 		correctAnswer: 1,
 	},
-	{
-		question: "Consectetur adipiscing elit",
-		answers: [
-			{
-				label: "Option 1",
-				value: 1,
+		{
+			question: <Quiz.QuestionLabel text="Consectetur adipiscing elit" />,
+			answers: [
+				{
+					label: <Quiz.OptionLabel text="Option 1" />,
+					value: 1,
 				feedback: (
 					<PrismFormatted
 						text={\`<p>Quaerat in autem sapiente illum. Vel mollitia omnis qui dolorem <code>um</code> esse eos maiores possimus. Est laborum quam aliquam qui sunt. Ut ea et qui provident voluptatibus. Eius quam odit sint cumque sint. Corporis quia et dicta.</p>\`}
@@ -505,22 +537,22 @@ const initialQuestions = [
 					/>
 				),
 			},
-			{
-				label: "Option 2",
-				value: 2,
+				{
+					label: <Quiz.OptionLabel text="Option 2" />,
+					value: 2,
 				feedback:
 					"Recusandae necessitatibus consequatur voluptatem sapiente.",
-			},
-			{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
-		],
+				},
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3, feedback: "Voluptas et et animi quo." },
+			],
 		correctAnswer: 2,
 	},
-	{
-		question: "Fugit itaque delectus voluptatem alias aliquid",
-		answers: [
-			{
-				label: "Option 1",
-				value: 1,
+		{
+			question: <Quiz.QuestionLabel text="Fugit itaque delectus voluptatem alias aliquid" />,
+			answers: [
+				{
+					label: <Quiz.OptionLabel text="Option 1" />,
+					value: 1,
 				feedback: (
 					<PrismFormatted
 						text={\`<p>Quaerat in autem sapiente illum. Vel mollitia omnis qui dolorem <code>um</code> esse eos maiores possimus. Est laborum quam aliquam qui sunt. Ut ea et qui provident voluptatibus. Eius quam odit sint cumque sint. Corporis quia et dicta.</p>\`}
@@ -528,14 +560,14 @@ const initialQuestions = [
 					/>
 				),
 			},
-			{
-				label: "Option 2",
-				value: 2,
+				{
+					label: <Quiz.OptionLabel text="Option 2" />,
+					value: 2,
 				feedback:
 					"Recusandae necessitatibus consequatur voluptatem sapiente.",
-			},
-			{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
-		],
+				},
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3, feedback: "Voluptas et et animi quo." },
+			],
 		correctAnswer: 3,
 	},
 ];
@@ -586,12 +618,12 @@ export const WithCorrectAnswersShownOnSuccess: Story = {
 import { Quiz, useQuiz, Button, Spacer } from '@freecodecamp/ui';
 
 const initialQuestions = [
-  {
-		question: "Lorem ipsum dolor sit amet",
-		answers: [
-			{
-				label: "Option 1",
-				value: 1,
+		{
+			question: <Quiz.QuestionLabel text="Lorem ipsum dolor sit amet" />,
+			answers: [
+				{
+					label: <Quiz.OptionLabel text="Option 1" />,
+					value: 1,
 				feedback: (
 					<PrismFormatted
 						text={\`<p>Quaerat in autem sapiente illum. Vel mollitia omnis qui dolorem <code>um</code> esse eos maiores possimus. Est laborum quam aliquam qui sunt. Ut ea et qui provident voluptatibus. Eius quam odit sint cumque sint. Corporis quia et dicta.</p>\`}
@@ -599,14 +631,14 @@ const initialQuestions = [
 					/>
 				),
 			},
-			{
-				label: "Option 2",
-				value: 2,
+				{
+					label: <Quiz.OptionLabel text="Option 2" />,
+					value: 2,
 				feedback:
 					"Recusandae necessitatibus consequatur voluptatem sapiente.",
-			},
-			{ label: "Option 3", value: 3, feedback: "Voluptas et et animi quo." },
-		],
+				},
+				{ label: <Quiz.OptionLabel text="Option 3" />, value: 3, feedback: "Voluptas et et animi quo." },
+			],
 		correctAnswer: 1,
 	},
 	{

--- a/src/quiz/quiz.tsx
+++ b/src/quiz/quiz.tsx
@@ -1,9 +1,52 @@
 import React from "react";
 
 import { QuizQuestion } from "../quiz-question";
+import { PrismFormatted } from "../prism-formatted";
 import { type QuizProps } from "./types";
 
-export const Quiz = <AnswerT extends number | string>({
+type LabelProps = { text: string };
+
+const removeParagraphTags = (text: string): string => {
+	// Remove a single pair of wrapping <p>...</p> tags if present
+	// without affecting inner HTML or code blocks.
+	if (text.startsWith("<p>") && text.endsWith("</p>")) {
+		return text.slice(3, -4);
+	}
+	return text;
+};
+
+const defaultGetCodeBlockAriaLabel = (codeName: string) =>
+	`${codeName} code example`;
+
+const QuestionLabel = ({ text }: LabelProps) => {
+	return (
+		<PrismFormatted
+			text={text}
+			getCodeBlockAriaLabel={defaultGetCodeBlockAriaLabel}
+		/>
+	);
+};
+
+const OptionLabel = ({ text }: LabelProps) => {
+	const cleanedText = removeParagraphTags(text);
+	return (
+		<PrismFormatted
+			text={cleanedText}
+			useSpan
+			noAria
+			getCodeBlockAriaLabel={defaultGetCodeBlockAriaLabel}
+		/>
+	);
+};
+
+type QuizComponent = (<AnswerT extends number | string>(
+	props: QuizProps<AnswerT>,
+) => JSX.Element) & {
+	QuestionLabel: typeof QuestionLabel;
+	OptionLabel: typeof OptionLabel;
+};
+
+const QuizBase = <AnswerT extends number | string>({
 	questions,
 	disabled,
 	required,
@@ -23,3 +66,8 @@ export const Quiz = <AnswerT extends number | string>({
 		</ul>
 	);
 };
+
+export const Quiz: QuizComponent = Object.assign(QuizBase, {
+	QuestionLabel,
+	OptionLabel,
+});


### PR DESCRIPTION
This PR adds `QuestionLabel` and `OptionLabel` subcomponents to the Quiz and QuizQuestion components.

- Adds `QuestionLabel` as a wrapper around `PrismFormatted` for rendering question text.
- Adds `OptionLabel` as a wrapper that uses `removeParagraphTags` and renders `PrismFormatted` with `useSpan` and `noAria`.
- Attaches these as subcomponents:
  - `Quiz.QuestionLabel`, `Quiz.OptionLabel`
  - `QuizQuestion.QuestionLabel`, `QuizQuestion.OptionLabel`
- Updates Quiz and QuizQuestion Storybook stories to use these new subcomponents.

Closes #572.

