### PR TITLE
fix(QuizQuestion): align position and question text along baseline

### DIFF
--- a/src/quiz-question/quiz-question.stories.tsx
+++ b/src/quiz-question/quiz-question.stories.tsx
@@ -553,4 +553,52 @@ print(cel)
 	},
 };
 
+export const WithRubyText: Story = {
+	render: QuizQuestionComp,
+	args: {
+		question: (
+			<span>
+				What does{" "}
+				<ruby>
+					你好<rt>nǐ hǎo</rt>
+				</ruby>{" "}
+				mean?
+			</span>
+		),
+		answers: [
+			{ label: "Hello", value: 1 },
+			{ label: "Goodbye", value: 2 },
+			{ label: "Thank you", value: 3 },
+		],
+		position: 1,
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `const App = () => {
+  const [answer, setAnswer] = useState();
+
+  return (
+    <QuizQuestion
+      question={
+        <span>
+          What does <ruby>你好<rt>nǐ hǎo</rt></ruby> mean?
+        </span>
+      }
+      answers={[
+        { label: "Hello", value: 1 },
+        { label: "Goodbye", value: 2 },
+        { label: "Thank you", value: 3 }
+      ]}
+      onChange={(newAnswer) => setAnswer(newAnswer)}
+      selectedAnswer={answer}
+			position={1}
+    />
+  );
+}`,
+			},
+		},
+	},
+};
+
 export default story;

--- a/src/quiz-question/quiz-question.tsx
+++ b/src/quiz-question/quiz-question.tsx
@@ -16,7 +16,7 @@ const QuestionText = ({
 	}
 
 	return (
-		<span className="text-foreground-primary flex">
+		<span className="text-foreground-primary flex items-baseline">
 			<span>{position}.</span>
 			&nbsp;
 			{question}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There is a misalignment issue in Chinese quiz:

<img width="781" height="136" alt="Screenshot 2025-12-15 at 03 55 49" src="https://github.com/user-attachments/assets/73738ea4-9548-41d0-98bf-26e6daeae568" />

The fix here is to add `align-items: baseline` (via the `items-baseline` Tailwind class) to align the position and question text along the baseline of their first line of text.

## Screenshot

Ignore the `ruby` font size here - I'll port the styles to the library once we're happy with how Chinese text is displayed on /learn.

<img width="1122" height="292" alt="Screenshot 2025-12-15 at 03 57 06" src="https://github.com/user-attachments/assets/c8a7f075-f26f-49e2-9698-9573e9883ddd" />



<!-- Feel free to add any additional description of changes below this line -->
