### PR TITLE
feat(ui): add renderAnswerAction to QuizQuestion for aligned answer actions

### DIFF
--- a/src/quiz-question/quiz-question.test.tsx
+++ b/src/quiz-question/quiz-question.test.tsx
@@ -300,6 +300,28 @@ describe("<QuizQuestion />", () => {
 			within(radioGroup).queryByText("Culpa dolores aut."),
 		).not.toBeInTheDocument();
 	});
+
+	it("should render action buttons if `renderAnswerAction` is provided", () => {
+		const handleAction = jest.fn();
+		render(
+			<QuizQuestion
+				question="Lorem ipsum"
+				answers={[
+					{ label: "Option 1", value: 1 },
+					{ label: "Option 2", value: 2 },
+				]}
+				// @ts-expect-error - renderAnswerAction is not in types yet
+				renderAnswerAction={(answer) => (
+					<button onClick={() => handleAction(answer.value)}>
+						Action {answer.value}
+					</button>
+				)}
+			/>,
+		);
+
+		expect(screen.getByText("Action 1")).toBeInTheDocument();
+		expect(screen.getByText("Action 2")).toBeInTheDocument();
+	});
 });
 
 // ------------------------------

--- a/src/quiz-question/quiz-question.tsx
+++ b/src/quiz-question/quiz-question.tsx
@@ -40,7 +40,10 @@ export const QuizQuestion = <AnswerT extends number | string>({
 	selectedAnswer,
 	onChange,
 	position,
-}: QuizQuestionProps<AnswerT>) => {
+	renderAnswerAction,
+}: QuizQuestionProps<AnswerT> & {
+	renderAnswerAction?: (answer: QuizQuestionAnswer<AnswerT>) => ReactNode;
+}) => {
 	const handleChange = (
 		selectedOption: QuizQuestionAnswer<AnswerT>["value"],
 	) => {
@@ -53,6 +56,7 @@ export const QuizQuestion = <AnswerT extends number | string>({
 
 	return (
 		<RadioGroup
+			as="fieldset"
 			onChange={handleChange}
 			aria-required={required}
 			disabled={disabled}
@@ -60,25 +64,51 @@ export const QuizQuestion = <AnswerT extends number | string>({
 			// or React will automatically consider QuizQuestion an uncontrolled component
 			// Ref: https://react.dev/reference/react-dom/components/input#im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled
 			value={selectedAnswer ?? null}
+			className="grid grid-cols-[1fr_auto] gap-4 items-center min-w-0"
 		>
-			<RadioGroup.Label className="block mb-[20px]">
+			<RadioGroup.Label as="legend" className="col-span-full block mb-[20px]">
 				<QuestionText question={question} position={position} />
 			</RadioGroup.Label>
 
-			{answers.map(({ value, label, feedback, validation }) => {
-				const checked = selectedAnswer === value;
-				return (
-					<Answer
-						key={value}
-						value={value}
-						label={label}
-						feedback={checked && validation && feedback}
-						checked={checked}
-						disabled={disabled}
-						validation={validation}
-					/>
-				);
-			})}
+			<div className="contents">
+				{answers.map(({ value, label, feedback, validation }, index) => {
+					const checked = selectedAnswer === value;
+					const rowIndex = index + 2;
+					return (
+						<div
+							key={value}
+							className="col-start-1"
+							style={{ gridRow: rowIndex }}
+						>
+							<Answer
+								value={value}
+								label={label}
+								feedback={checked && validation && feedback}
+								checked={checked}
+								disabled={disabled}
+								validation={validation}
+							/>
+						</div>
+					);
+				})}
+			</div>
+
+			{renderAnswerAction && (
+				<div className="contents">
+					{answers.map((answer, index) => {
+						const rowIndex = index + 2;
+						return (
+							<div
+								key={answer.value}
+								className="col-start-2"
+								style={{ gridRow: rowIndex }}
+							>
+								{renderAnswerAction(answer)}
+							</div>
+						);
+					})}
+				</div>
+			)}
 		</RadioGroup>
 	);
 };


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

Closes #660 

## Problem 
The current MCQ component in /learn needs to support a "speaking feature" where users can practice pronouncing specific answers. However, the existing QuizQuestion component did not support adding extra action buttons next to answers without either:

- Breaking the semantic structure (moving buttons inside the label/input group).
- Breaking visual alignment (buttons not lining up with multiline answer text).
- Requiring complex JavaScript to calculate heights and offsets.

## Solution 
This PR refactors the QuizQuestion component to use CSS Grid with display: contents, enabling perfect visual alignment while maintaining a clean semantic DOM structure.

- CSS Grid Layout: The parent <fieldset> now uses a 2-column grid (1fr auto).
- display: contents: Wrappers <div>s for answers and actions use display: contents, allowing their children to participate directly in the parent grid layout. This keeps the DOM grouped logically (Answers in one group, Actions in another) but aligns them visually in the same rows.
- renderAnswerAction Prop: Added a new optional prop that accepts a render function. This allows consumers to render custom components (like a "Practice speaking" button) next to each answer.
- Row Alignment: Used inline grid-row styles to ensure that the answer and its corresponding action always share the same vertical space, even if the answer text wraps to multiple lines.

## Testing

- Added a unit test in [quiz-question.test.tsx] to verify that renderAnswerAction correctly renders elements for each answer.
Verified that the semantic structure remains a valid <fieldset> with a <legend>.

This approach solves the issue and is a better semantic issue, tested locally also.
If any further changes are to be made please let me know, I will be happy to resolve it and if everything seems good, hope this PR will get Merged!
